### PR TITLE
Add skeleton `docker trust` commands and subcommands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/cli/cli/command/stack"
 	"github.com/docker/cli/cli/command/swarm"
 	"github.com/docker/cli/cli/command/system"
+	"github.com/docker/cli/cli/command/trust"
 	"github.com/docker/cli/cli/command/volume"
 	"github.com/spf13/cobra"
 )
@@ -68,6 +69,9 @@ func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 
 		// swarm
 		swarm.NewSwarmCommand(dockerCli),
+
+		// trust
+		trust.NewTrustCommand(dockerCli),
 
 		// volume
 		volume.NewVolumeCommand(dockerCli),

--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -1,0 +1,27 @@
+package trust
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+// NewTrustCommand returns a cobra command for `trust` subcommands
+func NewTrustCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trust",
+		Short: "Sign images to establish trust",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	cmd.AddCommand(
+		newConfigCommand(dockerCli),
+		newInfoCommand(dockerCli),
+		newInitCommand(dockerCli),
+		newKeyCommand(dockerCli),
+		newRevokeCommand(dockerCli),
+		newSignCommand(dockerCli),
+		newSignerCommand(dockerCli),
+	)
+	return cmd
+}

--- a/cli/command/trust/config.go
+++ b/cli/command/trust/config.go
@@ -1,0 +1,17 @@
+package trust
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+func newConfigCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config [OPTIONS]",
+		Short: "Configure trust settings",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	return cmd
+}

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -1,0 +1,17 @@
+package trust
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+func newInfoCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "info [OPTIONS]",
+		Short: "Display detailed information about keys and signatures",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	return cmd
+}

--- a/cli/command/trust/init.go
+++ b/cli/command/trust/init.go
@@ -1,0 +1,17 @@
+package trust
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+func newInitCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init [OPTIONS]",
+		Short: "Initialize trust for an image without pushing",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	return cmd
+}

--- a/cli/command/trust/key.go
+++ b/cli/command/trust/key.go
@@ -1,0 +1,17 @@
+package trust
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+func newKeyCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "key [OPTIONS]",
+		Short: "Operates on signing keys",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	return cmd
+}

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -1,0 +1,17 @@
+package trust
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+func newRevokeCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revoke [OPTIONS]",
+		Short: "Remove trust for an image",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	return cmd
+}

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -1,0 +1,17 @@
+package trust
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+func newSignCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sign [OPTIONS]",
+		Short: "Sign an image",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	return cmd
+}

--- a/cli/command/trust/signer.go
+++ b/cli/command/trust/signer.go
@@ -1,0 +1,17 @@
+package trust
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+func newSignerCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "signer [OPTIONS]",
+		Short: "Manage trusted signers for an image",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	return cmd
+}

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -32,28 +32,32 @@ build_shell_validate_image:
 
 # build executable using a container
 binary: build_docker_image
-	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make binary
+	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make binary
 
 build: binary
 
 # clean build artifacts using a container
 .PHONY: clean
 clean: build_docker_image
-	docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make clean
+	docker run -ti --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make clean
 
 # run go test
 .PHONY: test
 test: build_docker_image
-	docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make test
+	docker run -ti --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make test
 
 # build the CLI for multiple architectures using a container
 .PHONY: cross
 cross: build_cross_image
-	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
+	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
+
+.PHONY: cross-shell
+cross-shell: build_cross_image
+	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) bash
 
 .PHONY: watch
 watch: build_docker_image
-	docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make watch
+	docker run -ti --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make watch
 
 # start container in interactive mode for in-container development
 .PHONY: dev

--- a/scripts/build/cross
+++ b/scripts/build/cross
@@ -3,7 +3,7 @@
 # Build a binary for all supported platforms
 #
 
-set -eu -o pipefail
+set -eux -o pipefail
 
 BUILDDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export SHELL=bash


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added cobra commands for docker trust per the design doc. This also adds some basic setup to improve building binaries locally

**- How to verify it**
Run:
```
$make -f docker.Makefile cross-shell
[...]:/go/src/github.com/docker/cli# ./scripts/build/osx
```
And in a separate terminal:
```./build/docker-darwin-amd64 trust```

