### PR TITLE
Add flags for `docker trust info`

### DIFF
--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -6,12 +6,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type infoOptions struct {
+	tagsOnly bool
+	keysOnly bool
+}
+
 func newInfoCommand(dockerCli command.Cli) *cobra.Command {
+	var opts infoOptions
 	cmd := &cobra.Command{
 		Use:   "info [OPTIONS]",
 		Short: "Display detailed information about keys and signatures",
 		Args:  cli.NoArgs,
 		RunE:  command.ShowHelp(dockerCli.Err()),
 	}
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.tagsOnly, "tags-only", "t", false, "Show all signed tags only")
+	flags.BoolVarP(&opts.keysOnly, "keys-only", "k", false, "Show only keys and delegations known to the repo")
 	return cmd
 }


### PR DESCRIPTION
**- How to verify it**
```
$ make -f docker.Makefile cross-shell
#  ./scripts/build/osx
```
In another terminal:
```
$ ./build/docker-darwin-amd64 trust info --keys-only
$ ./build/docker-darwin-amd64 trust info --tags-only
```