### PR TITLE
trust info: show single signature info, not pretty yet

### DIFF
--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -1,17 +1,63 @@
 package trust
 
 import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/trust"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/registry"
+	"github.com/docker/notary"
 	"github.com/spf13/cobra"
 )
 
 func newInfoCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "info [OPTIONS]",
+		Use:   "info [OPTIONS] IMAGE",
 		Short: "Display detailed information about keys and signatures",
-		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return lookupTrustInfo(dockerCli, args[0])
+		},
 	}
 	return cmd
+}
+
+func lookupTrustInfo(cli command.Cli, remote string) error {
+	ref, err := reference.ParseNormalizedNamed(remote)
+	if err != nil {
+		return err
+	}
+
+	// Resolve the Repository name from fqn to RepositoryInfo
+	repoInfo, err := registry.ParseRepositoryInfo(ref)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
+
+	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, authConfig, "pull")
+	if err != nil {
+		fmt.Fprintf(cli.Out(), "Error establishing connection to notary repository: %s\n", err)
+		return err
+	}
+
+	targetList, err := notaryRepo.ListTargets("")
+	if err != nil {
+		// TODO(riyazdf): switch on error types for better messaging if not signed vs. other things
+		fmt.Fprintf(cli.Out(), "Error retrieving tags from notary repository: %s\n", err)
+		return err
+	}
+	fmt.Fprintf(cli.Out(), "SIGNATURE DATA FOR %s:\n\n", remote)
+	for _, tgt := range targetList {
+		prettyHash := base64.StdEncoding.EncodeToString(tgt.Hashes[notary.SHA256])
+		fmt.Fprintf(cli.Out(), "%s\t%s\t%d\t%s\n", tgt.Name, prettyHash, tgt.Length, tgt.Role)
+	}
+
+	return nil
 }

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -1,0 +1,75 @@
+package trust
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeClient struct {
+	client.Client
+}
+
+func TestTrustInfoErrors(t *testing.T) {
+	testCases := []struct {
+		name          string
+		args          []string
+		expectedError string
+	}{
+		{
+			name:          "not-enough-args",
+			expectedError: "requires exactly 1 argument",
+		},
+		{
+			name:          "too-many-args",
+			args:          []string{"remote1", "remote2"},
+			expectedError: "requires exactly 1 argument",
+		},
+		{
+			name:          "sha-reference",
+			args:          []string{"870d292919d01a0af7e7f056271dc78792c05f55f49b9b9012b6d89725bd9abd"},
+			expectedError: "invalid repository name",
+		},
+		{
+			name:          "nonexistent-reg",
+			args:          []string{"nonexistent-reg-name.io/image"},
+			expectedError: "no such host",
+		},
+		{
+			name:          "invalid-img-reference",
+			args:          []string{"ALPINE"},
+			expectedError: "invalid reference format",
+		},
+		{
+			name:          "unsigned-img-reference",
+			args:          []string{"riyaz/unsigned-img"},
+			expectedError: "notary.docker.io does not have trust data for docker.io/riyaz/unsigned-img",
+		},
+		{
+			name:          "nonexistent-img-reference",
+			args:          []string{"riyaz/nonexistent-img"},
+			expectedError: "you are not authorized to perform this operation: server returned 401",
+		},
+	}
+	for _, tc := range testCases {
+		buf := new(bytes.Buffer)
+		cmd := newInfoCommand(
+			test.NewFakeCliWithOutput(&fakeClient{}, buf))
+		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+	}
+}
+
+func TestTrustInfo(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cmd := newInfoCommand(
+		test.NewFakeCliWithOutput(&fakeClient{}, buf))
+	cmd.SetArgs([]string{"alpine"})
+	assert.NoError(t, cmd.Execute())
+}


### PR DESCRIPTION
Part of #5 but only matches the `notary list` info – will follow up with multsignature support and pretty printing in separate PR(s).

Note that `notaryRepo.ListTargets("")` will likely go away so the advanced error handling TODO is not relevant.

cc @ashfall @eiais for review

<img src="http://new4.fjcdn.com/pictures/Cute+cat+with+a+duck+hat+du+och+jag_172bba_4895383.jpg" width="400"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
