### PR TITLE
trust info: gather and display multiple signatures

### DIFF
--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -131,6 +131,9 @@ func matchReleasedSignatures(allTargets []client.TargetSignedStruct) ([]trustTag
 		signatureRows = append(signatureRows, trustTagRow{targetKey, signers})
 	}
 	sort.Sort(signatureRows)
+	if len(signatureRows) == 0 {
+		return nil, fmt.Errorf("no signatures for image")
+	}
 	return signatureRows, nil
 }
 

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -2,8 +2,9 @@ package trust
 
 import (
 	"context"
-	"encoding/base64"
+	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -11,8 +12,36 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/registry"
 	"github.com/docker/notary"
+	"github.com/docker/notary/client"
+	"github.com/docker/notary/tuf/data"
 	"github.com/spf13/cobra"
 )
+
+const releasedRoleName = "owner"
+
+type trustTagKey struct {
+	TagName string
+	HashHex string
+}
+
+type trustTagRow struct {
+	trustTagKey
+	Signers []string
+}
+
+// check if a role name is "released": either targets/releases or targets TUF roles
+func isReleasedTarget(role data.RoleName) bool {
+	return role == data.CanonicalTargetsRole || role == trust.ReleasesRole
+}
+
+// convert TUF role name to a human-understandable signer name
+func notaryRoleToSigner(tufRole data.RoleName) string {
+	//  don't show a signer for "targets" or "targets/releases"
+	if isReleasedTarget(data.RoleName(tufRole.String())) {
+		return releasedRoleName
+	}
+	return strings.TrimPrefix(tufRole.String(), "targets/")
+}
 
 func newInfoCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
@@ -43,21 +72,56 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 
 	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, authConfig, "pull")
 	if err != nil {
-		fmt.Fprintf(cli.Out(), "Error establishing connection to notary repository: %s\n", err)
-		return err
+		return trust.NotaryError(ref.Name(), err)
 	}
 
-	targetList, err := notaryRepo.ListTargets("")
+	// Retrieve released signatures and pretty print them
+	signatureRows, err := lookupSignatures(notaryRepo)
 	if err != nil {
-		// TODO(riyazdf): switch on error types for better messaging if not signed vs. other things
-		fmt.Fprintf(cli.Out(), "Error retrieving tags from notary repository: %s\n", err)
-		return err
+		return trust.NotaryError(ref.Name(), err)
 	}
-	fmt.Fprintf(cli.Out(), "SIGNATURE DATA FOR %s:\n\n", remote)
-	for _, tgt := range targetList {
-		prettyHash := base64.StdEncoding.EncodeToString(tgt.Hashes[notary.SHA256])
-		fmt.Fprintf(cli.Out(), "%s\t%s\t%d\t%s\n", tgt.Name, prettyHash, tgt.Length, tgt.Role)
-	}
+	printSignatures(cli, remote, signatureRows)
 
 	return nil
+}
+
+func lookupSignatures(notaryRepo *client.NotaryRepository) ([]trustTagRow, error) {
+	signatureRows := []trustTagRow{}
+	allTargets, err := notaryRepo.GetAllTargetMetadataByName("")
+	if err != nil {
+		return nil, err
+	}
+
+	// do a first pass to get filter on tags signed into "targets" or "targets/releases"
+	releasedTargetRows := map[trustTagKey][]string{}
+	for _, tgt := range allTargets {
+		if isReleasedTarget(tgt.Role.Name) {
+			releasedKey := trustTagKey{tgt.Target.Name, hex.EncodeToString(tgt.Target.Hashes[notary.SHA256])}
+			releasedTargetRows[releasedKey] = []string{}
+		}
+	}
+
+	// now fill out all signers on released keys
+	for _, tgt := range allTargets {
+		targetKey := trustTagKey{tgt.Target.Name, hex.EncodeToString(tgt.Target.Hashes[notary.SHA256])}
+		// only considered released targets
+		if _, ok := releasedTargetRows[targetKey]; ok && !isReleasedTarget(tgt.Role.Name) {
+			releasedTargetRows[targetKey] = append(releasedTargetRows[targetKey], notaryRoleToSigner(tgt.Role.Name))
+		}
+	}
+
+	// compile the final output as a slice
+	for targetKey, signers := range releasedTargetRows {
+		signatureRows = append(signatureRows, trustTagRow{targetKey, signers})
+	}
+
+	return signatureRows, nil
+}
+
+// TODO(riyazdf): pretty print with ordered rows
+func printSignatures(cli command.Cli, imageName string, signatureRows []trustTagRow) {
+	fmt.Fprintf(cli.Out(), "SIGNATURE DATA FOR %s:\n\n", imageName)
+	for _, sigRow := range signatureRows {
+		fmt.Fprintf(cli.Out(), "%s\t%s\t\t%s\n", sigRow.TagName, sigRow.HashHex, sigRow.Signers)
+	}
 }

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -2,19 +2,22 @@ package trust
 
 import (
 	"bytes"
+	"encoding/hex"
 	"io/ioutil"
 	"testing"
 
 	"github.com/docker/cli/cli/internal/test"
 	"github.com/docker/cli/cli/trust"
-	"github.com/docker/docker/client"
+	dockerClient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/testutil"
+	"github.com/docker/notary"
+	"github.com/docker/notary/client"
 	"github.com/docker/notary/tuf/data"
 	"github.com/stretchr/testify/assert"
 )
 
 type fakeClient struct {
-	client.Client
+	dockerClient.Client
 }
 
 func TestTrustInfoErrors(t *testing.T) {
@@ -101,4 +104,153 @@ func TestIsReleasedTarget(t *testing.T) {
 	assert.False(t, isReleasedTarget(data.RoleName("targets/not-releases")))
 	assert.False(t, isReleasedTarget(data.RoleName("random")))
 	assert.False(t, isReleasedTarget(data.RoleName("targets/releases/subrole")))
+}
+
+// creates a mock delegation with a given name and no keys
+func mockDelegationRoleWithName(name string) data.DelegationRole {
+	baseRole := data.NewBaseRole(
+		data.RoleName(name),
+		notary.MinThreshold,
+	)
+	return data.DelegationRole{baseRole, []string{}}
+}
+
+func TestMatchEmptySignatures(t *testing.T) {
+	// first try empty targets
+	emptyTgts := []client.TargetSignedStruct{}
+
+	matchedSigRows, err := matchReleasedSignatures(emptyTgts)
+	assert.NoError(t, err)
+	assert.Empty(t, matchedSigRows)
+}
+
+func TestMatchUnreleasedSignatures(t *testing.T) {
+	// try an "unreleased" target with 3 signatures, 0 rows will appear
+	unreleasedTgts := []client.TargetSignedStruct{}
+
+	tgt := client.Target{Name: "unreleased", Hashes: data.Hashes{notary.SHA256: []byte("hash")}}
+	for _, unreleasedRole := range []string{"targets/a", "targets/b", "targets/c"} {
+		unreleasedTgts = append(unreleasedTgts, client.TargetSignedStruct{Role: mockDelegationRoleWithName(unreleasedRole), Target: tgt})
+	}
+
+	matchedSigRows, err := matchReleasedSignatures(unreleasedTgts)
+	assert.NoError(t, err)
+	assert.Empty(t, matchedSigRows)
+}
+
+func TestMatchOneReleasedSingleSignature(t *testing.T) {
+	// now try only 1 "released" target with no additional sigs, 1 row will appear with 0 signers
+	oneReleasedTgt := []client.TargetSignedStruct{}
+
+	// make and append the "released" target to our mock input
+	releasedTgt := client.Target{Name: "released", Hashes: data.Hashes{notary.SHA256: []byte("released-hash")}}
+	oneReleasedTgt = append(oneReleasedTgt, client.TargetSignedStruct{Role: mockDelegationRoleWithName("targets/releases"), Target: releasedTgt})
+
+	// make and append 3 non-released signatures on the "unreleased" target
+	unreleasedTgt := client.Target{Name: "unreleased", Hashes: data.Hashes{notary.SHA256: []byte("hash")}}
+	for _, unreleasedRole := range []string{"targets/a", "targets/b", "targets/c"} {
+		oneReleasedTgt = append(oneReleasedTgt, client.TargetSignedStruct{Role: mockDelegationRoleWithName(unreleasedRole), Target: unreleasedTgt})
+	}
+
+	matchedSigRows, err := matchReleasedSignatures(oneReleasedTgt)
+	assert.NoError(t, err)
+	assert.Len(t, matchedSigRows, 1)
+
+	outputRow := matchedSigRows[0]
+	// Empty signers because "targets/releases" doesn't show up
+	assert.Empty(t, outputRow.Signers)
+	assert.Equal(t, releasedTgt.Name, outputRow.TagName)
+	assert.Equal(t, hex.EncodeToString(releasedTgt.Hashes[notary.SHA256]), outputRow.HashHex)
+}
+
+func TestMatchOneReleasedMultiSignature(t *testing.T) {
+	// now try only 1 "released" target with 3 additional sigs, 1 row will appear with 3 signers
+	oneReleasedTgt := []client.TargetSignedStruct{}
+
+	// make and append the "released" target to our mock input
+	releasedTgt := client.Target{Name: "released", Hashes: data.Hashes{notary.SHA256: []byte("released-hash")}}
+	oneReleasedTgt = append(oneReleasedTgt, client.TargetSignedStruct{Role: mockDelegationRoleWithName("targets/releases"), Target: releasedTgt})
+
+	// make and append 3 non-released signatures on both the "released" and "unreleased" targets
+	unreleasedTgt := client.Target{Name: "unreleased", Hashes: data.Hashes{notary.SHA256: []byte("hash")}}
+	for _, unreleasedRole := range []string{"targets/a", "targets/b", "targets/c"} {
+		oneReleasedTgt = append(oneReleasedTgt, client.TargetSignedStruct{Role: mockDelegationRoleWithName(unreleasedRole), Target: unreleasedTgt})
+		oneReleasedTgt = append(oneReleasedTgt, client.TargetSignedStruct{Role: mockDelegationRoleWithName(unreleasedRole), Target: releasedTgt})
+	}
+
+	matchedSigRows, err := matchReleasedSignatures(oneReleasedTgt)
+	assert.NoError(t, err)
+	assert.Len(t, matchedSigRows, 1)
+
+	outputRow := matchedSigRows[0]
+	// We should have three signers
+	assert.Equal(t, outputRow.Signers, []string{"a", "b", "c"})
+	assert.Equal(t, releasedTgt.Name, outputRow.TagName)
+	assert.Equal(t, hex.EncodeToString(releasedTgt.Hashes[notary.SHA256]), outputRow.HashHex)
+}
+
+func TestMatchMultiReleasedMultiSignature(t *testing.T) {
+	// now try 3 "released" targets with additional sigs to show 3 rows as follows:
+	// target-a is signed by targets/releases and targets/a - a will be the signer
+	// target-b is signed by targets/releases, targets/a, targets/b - a and b will be the signers
+	// target-c is signed by targets/releases, targets/a, targets/b, targets/c - a, b, and c will be the signers
+	multiReleasedTgts := []client.TargetSignedStruct{}
+	// make target-a, target-b, and target-c
+	targetA := client.Target{Name: "target-a", Hashes: data.Hashes{notary.SHA256: []byte("target-a-hash")}}
+	targetB := client.Target{Name: "target-b", Hashes: data.Hashes{notary.SHA256: []byte("target-b-hash")}}
+	targetC := client.Target{Name: "target-c", Hashes: data.Hashes{notary.SHA256: []byte("target-c-hash")}}
+
+	// have targets/releases "sign" on all of these targets so they are released
+	multiReleasedTgts = append(multiReleasedTgts, client.TargetSignedStruct{Role: mockDelegationRoleWithName("targets/releases"), Target: targetA})
+	multiReleasedTgts = append(multiReleasedTgts, client.TargetSignedStruct{Role: mockDelegationRoleWithName("targets/releases"), Target: targetB})
+	multiReleasedTgts = append(multiReleasedTgts, client.TargetSignedStruct{Role: mockDelegationRoleWithName("targets/releases"), Target: targetC})
+
+	// targets/a signs off on all three targets (target-a, target-b, target-c):
+	for _, tgt := range []client.Target{targetA, targetB, targetC} {
+		multiReleasedTgts = append(multiReleasedTgts, client.TargetSignedStruct{Role: mockDelegationRoleWithName("targets/a"), Target: tgt})
+	}
+
+	// targets/b signs off on the final two targets (target-b, target-c):
+	for _, tgt := range []client.Target{targetB, targetC} {
+		multiReleasedTgts = append(multiReleasedTgts, client.TargetSignedStruct{Role: mockDelegationRoleWithName("targets/b"), Target: tgt})
+	}
+
+	// targets/c only signs off on the last target (target-c):
+	multiReleasedTgts = append(multiReleasedTgts, client.TargetSignedStruct{Role: mockDelegationRoleWithName("targets/c"), Target: targetC})
+
+	matchedSigRows, err := matchReleasedSignatures(multiReleasedTgts)
+	assert.NoError(t, err)
+	assert.Len(t, matchedSigRows, 3)
+
+	// note that the output is sorted by tag name, so we can reliably index to validate data:
+	outputTargetA := matchedSigRows[0]
+	assert.Equal(t, outputTargetA.Signers, []string{"a"})
+	assert.Equal(t, targetA.Name, outputTargetA.TagName)
+	assert.Equal(t, hex.EncodeToString(targetA.Hashes[notary.SHA256]), outputTargetA.HashHex)
+
+	outputTargetB := matchedSigRows[1]
+	assert.Equal(t, outputTargetB.Signers, []string{"a", "b"})
+	assert.Equal(t, targetB.Name, outputTargetB.TagName)
+	assert.Equal(t, hex.EncodeToString(targetB.Hashes[notary.SHA256]), outputTargetB.HashHex)
+
+	outputTargetC := matchedSigRows[2]
+	assert.Equal(t, outputTargetC.Signers, []string{"a", "b", "c"})
+	assert.Equal(t, targetC.Name, outputTargetC.TagName)
+	assert.Equal(t, hex.EncodeToString(targetC.Hashes[notary.SHA256]), outputTargetC.HashHex)
+}
+
+func TestMatchReleasedSignatureFromTargets(t *testing.T) {
+	// now try only 1 "released" target with no additional sigs, one rows will appear
+	oneReleasedTgt := []client.TargetSignedStruct{}
+	// make and append the "released" target to our mock input
+	releasedTgt := client.Target{Name: "released", Hashes: data.Hashes{notary.SHA256: []byte("released-hash")}}
+	oneReleasedTgt = append(oneReleasedTgt, client.TargetSignedStruct{Role: mockDelegationRoleWithName(data.CanonicalTargetsRole.String()), Target: releasedTgt})
+	matchedSigRows, err := matchReleasedSignatures(oneReleasedTgt)
+	assert.NoError(t, err)
+	assert.Len(t, matchedSigRows, 1)
+	outputRow := matchedSigRows[0]
+	// Empty signers because "targets" doesn't show up
+	assert.Empty(t, outputRow.Signers)
+	assert.Equal(t, releasedTgt.Name, outputRow.TagName)
+	assert.Equal(t, hex.EncodeToString(releasedTgt.Hashes[notary.SHA256]), outputRow.HashHex)
 }

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -120,7 +120,7 @@ func TestMatchEmptySignatures(t *testing.T) {
 	emptyTgts := []client.TargetSignedStruct{}
 
 	matchedSigRows, err := matchReleasedSignatures(emptyTgts)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	assert.Empty(t, matchedSigRows)
 }
 
@@ -134,7 +134,7 @@ func TestMatchUnreleasedSignatures(t *testing.T) {
 	}
 
 	matchedSigRows, err := matchReleasedSignatures(unreleasedTgts)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	assert.Empty(t, matchedSigRows)
 }
 


### PR DESCRIPTION
This gathers all signers for released signatures.  A "released" signature means it's in either the `targets` or `targets/releases` roles - if an image is not signed into one of those roles, docker cannot pull/run it with content trust so we omit it (this isn't exposed to the user).

This is sorted by tag-name and still needs to be properly pretty printed (see #6), but here's example output with delegation signers:
```
🐳 $ ./docker-darwin-amd64 trust info linuxkit/dhcpcd
SIGNATURE DATA FOR linuxkit/dhcpcd:

17423c1ccced74e3c005fd80486e8177841fe02b	4354a7736e7c3b373dc62e3738e303ba5615a43d87f7603b0aad54d01faecb31		[justin]
4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41	ca28b47c87f2c9689d69820a5e6cb114189b2467b3abcee7629c6f4e62e113f2		[justin]
69e847d1ae066f6be83a81c86ea712fb20ee7891	d58cbb0e6da4974d30430470cf25b9ffde12ed2389e540e950123489a6240fb5		[rolf]
6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae	129a415917480edacc3751d0dbbcd9c27b21a0def79546e5c9945d872923e4ea		[rolf]
7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1	b1bef35accd165a4235ad301f9bef6544922cb6eafdb60268b05d8c9d0b1566b		[justin]
7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e	3c9b5f8b16dff4a5338f1db1eca61e90fb4e607bfb1b8addd1b05f084f0a68e0		[rolf]
```

(note how `releases` doesn't show as a signer)

And with only targets signing (note how it doesn't show a `targets` signer):
```
🐳 $ ./docker-darwin-amd64 trust info alpine
SIGNATURE DATA FOR alpine:

2.6	9ace551613070689a12857d62c30ef0daa9a376107ec0fff0e34786cedb3399b		[]
2.7	9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a		[]
3.1	d9477888b78e8c6392e0be8b2e73f8c67e2894ff9d4b8e467d1488fcceec21c8		[]
3.2	19826d59171c2eb7e90ce52bfd822993bef6a6fe3ae6bb4a49f8c1d0a01e99c7		[]
3.3	8fd4b76819e1e5baac82bd0a3d03abfe3906e034cc5ee32100d12aaaf3956dc7		[]
3.4	833ad81ace8277324f3ca8c91c02bdcf1d13988d8ecf8a3f97ecdd69d0390ce9		[]
3.5	af2a5bd2f8de8fc1ecabf1c76611cdc6a5f1ada1a2bdd7d3816e121b70300308		[]
3.6	1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe		[]
edge	79d50d15bd7ea48ea00cf3dd343b0e740c1afaa8e899bee475236ef338e1b53b		[]
integ-test-base	3952dc48dcc4136ccdde37fbef7e250346538a55a0366e3fccc683336377e372		[]
latest	1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe		[]
```

Marked as WIP because I will write tests and potentially break down functions further to make it simpler to write my tests.  Wanted to open this sooner rather than later to get early feedback especially on helper functions that @ashfall may also want to use.

cc @ashfall @eiais @endophage

Closes #7 

<img src="http://r.fod4.com/s=w550,pd2/o=85/http://a.fod4.com/images/user_photos/1236168/6c66cb14a2fe16e241c616d36c53a3f4_original.jpg" width="400"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
