### PR TITLE
Display signer and admin role info

### DIFF
--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -254,3 +254,67 @@ func TestMatchReleasedSignatureFromTargets(t *testing.T) {
 	assert.Equal(t, releasedTgt.Name, outputRow.TagName)
 	assert.Equal(t, hex.EncodeToString(releasedTgt.Hashes[notary.SHA256]), outputRow.HashHex)
 }
+
+func TestGetSignerAndBaseRolesWithKeyIDs(t *testing.T) {
+	roles := []data.Role{
+		{
+			RootRole: data.RootRole{
+				KeyIDs: []string{"key11"},
+			},
+			Name: "targets/alice",
+		},
+		{
+			RootRole: data.RootRole{
+				KeyIDs: []string{"key21", "key22"},
+			},
+			Name: "targets/releases",
+		},
+		{
+			RootRole: data.RootRole{
+				KeyIDs: []string{"key31"},
+			},
+			Name: data.CanonicalRootRole,
+		},
+		{
+			RootRole: data.RootRole{
+				KeyIDs: []string{"key41"},
+			},
+			Name: data.CanonicalTargetsRole,
+		},
+		{
+			RootRole: data.RootRole{
+				KeyIDs: []string{"key51"},
+			},
+			Name: data.CanonicalSnapshotRole,
+		},
+		{
+			RootRole: data.RootRole{
+				KeyIDs: []string{"key61"},
+			},
+			Name: data.CanonicalTimestampRole,
+		},
+		{
+			RootRole: data.RootRole{
+				KeyIDs: []string{"key71", "key72"},
+			},
+			Name: "targets/bob",
+		},
+	}
+	expectedSignerRoleToKeyIDs := map[string][]string{
+		"alice": {"key11"},
+		"bob":   {"key71", "key72"},
+	}
+	expectedBaseRoleToKeyIDs := map[string][]string{
+		"root":  {"key31"},
+		"admin": {"key41"},
+	}
+
+	var roleWithSigs []client.RoleWithSignatures
+	for _, role := range roles {
+		roleWithSig := client.RoleWithSignatures{Role: role, Signatures: nil}
+		roleWithSigs = append(roleWithSigs, roleWithSig)
+	}
+	signerRoleToKeyIDs, baseRoleToKeyIDs := getSignerAndBaseRolesWithKeyIDs(roleWithSigs)
+	assert.Equal(t, signerRoleToKeyIDs, expectedSignerRoleToKeyIDs)
+	assert.Equal(t, baseRoleToKeyIDs, expectedBaseRoleToKeyIDs)
+}


### PR DESCRIPTION
Fixes #7 

Sample output:
```
$ ./build/docker-darwin-amd64 trust info linuxkit/dhcpcd
SIGNATURE DATA FOR linuxkit/dhcpcd:

17423c1ccced74e3c005fd80486e8177841fe02b	4354a7736e7c3b373dc62e3738e303ba5615a43d87f7603b0aad54d01faecb31		[justin]
4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41	ca28b47c87f2c9689d69820a5e6cb114189b2467b3abcee7629c6f4e62e113f2		[justin]
69e847d1ae066f6be83a81c86ea712fb20ee7891	d58cbb0e6da4974d30430470cf25b9ffde12ed2389e540e950123489a6240fb5		[rolf]
6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae	129a415917480edacc3751d0dbbcd9c27b21a0def79546e5c9945d872923e4ea		[rolf]
7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1	b1bef35accd165a4235ad301f9bef6544922cb6eafdb60268b05d8c9d0b1566b		[justin]
7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e	3c9b5f8b16dff4a5338f1db1eca61e90fb4e607bfb1b8addd1b05f084f0a68e0		[rolf]

List of signers and their KeyIDs:

Name 			 KeyIDs
rolf		[2fb3dc88c28433196e859a31a6561226594b7d65e0bf021f589d6b81cdd14d6e]
ian		[82a66673242c9c12078ebea9cae303f3ac52610d9299477ed82de0454f4e285f]
avi		[47caae5b3e61702d354c67706eccc40b90ec3e7c81f4c84522e2dee830e3df06]
ci		[74fc11c9c748aa1f51f578ac4ee1d85957b8763b12c4575d8b8f84870af2c657]
justin		[b6f9f8e1aab0676c4a7fd04eae5621a59fe15f97591eeb1a9ef7438ab6b0b0dc]
riyaz		[54ec40e02fd0af41d8e38dc8142ce60b890fcaacf355af43c26beb49f95b7e6a]

List of admins and their KeyIDs:

Name 			 KeyIDs
root		[2731adb1731af9d3566fc2775da4b928f8a322a01a76f50fecab4462765e877d]
admin		[43bdbe3ef4208934665ca98bc8b7b32fabcc4978344e7195d5eff2b088cb52a7]
```