### PR TITLE
trust info: pretty print signatures into a formatted table

### DIFF
--- a/cli/command/formatter/trust.go
+++ b/cli/command/formatter/trust.go
@@ -1,0 +1,70 @@
+package formatter
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	defaultTrustTagTableFormat = "table {{.SignedTag}}\t{{.Digest}}\t{{.Signers}}"
+	signedTagNameHeader        = "SIGNED TAG"
+	trustedDigestHeader        = "DIGEST"
+	signersHeader              = "SIGNERS"
+)
+
+// SignedTagInfo represents all formatted information needed to describe a signed tag:
+// Name: name of the signed tag
+// Digest: hex encoded digest of the contents
+// Signers: list of entities who signed the tag
+type SignedTagInfo struct {
+	Name    string
+	Digest  string
+	Signers []string
+}
+
+// NewTrustTagFormat returns a Format for rendering using a trusted tag Context
+func NewTrustTagFormat() Format {
+	return defaultTrustTagTableFormat
+}
+
+// TrustTagWrite writes the context
+func TrustTagWrite(ctx Context, signedTagInfoList []SignedTagInfo) error {
+	render := func(format func(subContext subContext) error) error {
+		for _, signedTag := range signedTagInfoList {
+			if err := format(&trustTagContext{s: signedTag}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	trustTagCtx := trustTagContext{}
+	trustTagCtx.header = trustTagHeaderContext{
+		"SignedTag": signedTagNameHeader,
+		"Digest":    trustedDigestHeader,
+		"Signers":   signersHeader,
+	}
+	return ctx.Write(&trustTagCtx, render)
+}
+
+type trustTagHeaderContext map[string]string
+
+type trustTagContext struct {
+	HeaderContext
+	s SignedTagInfo
+}
+
+// SignedTag returns the name of the signed tag
+func (c *trustTagContext) SignedTag() string {
+	return c.s.Name
+}
+
+// Digest returns the hex encoded digest associated with this signed tag
+func (c *trustTagContext) Digest() string {
+	return c.s.Digest
+}
+
+// Signers returns the sorted list of entities who signed this tag
+func (c *trustTagContext) Signers() string {
+	sort.Strings(c.s.Signers)
+	return strings.Join(c.s.Signers, ",")
+}

--- a/cli/command/formatter/trust_test.go
+++ b/cli/command/formatter/trust_test.go
@@ -1,0 +1,157 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrustTag(t *testing.T) {
+	digest := stringid.GenerateRandomID()
+	trustedTag := "tag"
+
+	var ctx trustTagContext
+
+	cases := []struct {
+		trustTagCtx trustTagContext
+		expValue    string
+		call        func() string
+	}{
+		{
+			trustTagContext{
+				s: SignedTagInfo{Name: trustedTag,
+					Digest:  digest,
+					Signers: nil,
+				},
+			},
+			digest,
+			ctx.Digest,
+		},
+		{
+			trustTagContext{
+				s: SignedTagInfo{Name: trustedTag,
+					Digest:  digest,
+					Signers: nil,
+				},
+			},
+			trustedTag,
+			ctx.SignedTag,
+		},
+		// Empty signers makes a row with empty string
+		{
+			trustTagContext{
+				s: SignedTagInfo{Name: trustedTag,
+					Digest:  digest,
+					Signers: nil,
+				},
+			},
+			"",
+			ctx.Signers,
+		},
+		{
+			trustTagContext{
+				s: SignedTagInfo{Name: trustedTag,
+					Digest:  digest,
+					Signers: []string{"ashwini", "kyle", "riyaz"},
+				},
+			},
+			"ashwini,kyle,riyaz",
+			ctx.Signers,
+		},
+		// alphabetic signing on Signers
+		{
+			trustTagContext{
+				s: SignedTagInfo{Name: trustedTag,
+					Digest:  digest,
+					Signers: []string{"riyaz", "kyle", "ashwini"},
+				},
+			},
+			"ashwini,kyle,riyaz",
+			ctx.Signers,
+		},
+	}
+
+	for _, c := range cases {
+		ctx = c.trustTagCtx
+		v := c.call()
+		if v != c.expValue {
+			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
+		}
+	}
+}
+
+func TestTrustTagContextWrite(t *testing.T) {
+
+	cases := []struct {
+		context  Context
+		expected string
+	}{
+		// Errors
+		{
+			Context{
+				Format: "{{InvalidFunction}}",
+			},
+			`Template parsing error: template: :1: function "InvalidFunction" not defined
+`,
+		},
+		{
+			Context{
+				Format: "{{nil}}",
+			},
+			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
+`,
+		},
+		// Table Format
+		{
+			Context{
+				Format: NewTrustTagFormat(),
+			},
+			`SIGNED TAG          DIGEST              SIGNERS
+tag1                deadbeef            alice
+tag2                aaaaaaaa            alice,bob
+tag3                bbbbbbbb            
+`,
+		},
+	}
+
+	for _, testcase := range cases {
+		signedTags := []SignedTagInfo{
+			{Name: "tag1", Digest: "deadbeef", Signers: []string{"alice"}},
+			{Name: "tag2", Digest: "aaaaaaaa", Signers: []string{"alice,bob"}},
+			{Name: "tag3", Digest: "bbbbbbbb", Signers: []string{}},
+		}
+		out := bytes.NewBufferString("")
+		testcase.context.Output = out
+		err := TrustTagWrite(testcase.context, signedTags)
+		if err != nil {
+			assert.EqualError(t, err, testcase.expected)
+		} else {
+			assert.Equal(t, testcase.expected, out.String())
+		}
+	}
+}
+
+// With no trust data, the TrustTagWrite will print an empty table:
+// it's up to the caller to decide whether or not to print this versus an error
+func TestTrustTagContextEmptyWrite(t *testing.T) {
+
+	emptyCase := struct {
+		context  Context
+		expected string
+	}{
+		Context{
+			Format: NewTrustTagFormat(),
+		},
+		`SIGNED TAG          DIGEST              SIGNERS
+`,
+	}
+
+	emptySignedTags := []SignedTagInfo{}
+	out := bytes.NewBufferString("")
+	emptyCase.context.Output = out
+	err := TrustTagWrite(emptyCase.context, emptySignedTags)
+	assert.NoError(t, err)
+	assert.Equal(t, emptyCase.expected, out.String())
+}


### PR DESCRIPTION
Partially addresses #6.  Sample (snipped) output below:

```
🐳 $ ./docker-darwin-amd64 trust info linuxkit/alpine
SIGNED TAG                                 DIGEST                                                             SIGNERS
9bcf61f605ef0ce36cc94d59b8eac307862de6e1   1de96f57d89b1f81dc0ad269ad3765fb2d3e2ceb3149d54ddad6cf8b826f5acd   justin,rolf
deadbeef                                   ace64c1b634887f28c3633fb34787e2b87e683f9d3a9eae7ec1a1e7f7cd6fbcc   riyaz,rolf
e01b0b8990ea19c432ec7a3c9db0b8ea6713e316   92e5c720cbf2e61e71ee853e0ddf4d6410596fd5d7b693b6d43658450b031608   ian
e79b1b4c35c0a6725cea020ade5b942a46afa0f0   62b9ea6f32551c99c888bb3442797d6cb806a00290e54b7dac5175cc226f0bc9   rolf
e84fa40c32a9cde669812a9b9ff2be0482eafeb3   af8565fa61a73961cd16f79fa17ea2a1f2b8450afb2198dd1eacb12f2f9fe43e   rolf
```

```
 🐳 $ ./docker-darwin-amd64 trust info alpine
SIGNED TAG          DIGEST                                                             SIGNERS
2.6                 9ace551613070689a12857d62c30ef0daa9a376107ec0fff0e34786cedb3399b
2.7                 9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a
3.1                 d9477888b78e8c6392e0be8b2e73f8c67e2894ff9d4b8e467d1488fcceec21c8
3.2                 19826d59171c2eb7e90ce52bfd822993bef6a6fe3ae6bb4a49f8c1d0a01e99c7
3.3                 8fd4b76819e1e5baac82bd0a3d03abfe3906e034cc5ee32100d12aaaf3956dc7
3.4                 833ad81ace8277324f3ca8c91c02bdcf1d13988d8ecf8a3f97ecdd69d0390ce9
3.5                 af2a5bd2f8de8fc1ecabf1c76611cdc6a5f1ada1a2bdd7d3816e121b70300308
3.6                 1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
edge                79d50d15bd7ea48ea00cf3dd343b0e740c1afaa8e899bee475236ef338e1b53b
integ-test-base     3952dc48dcc4136ccdde37fbef7e250346538a55a0366e3fccc683336377e372
latest              1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
```

```
🐳 $ ./docker-darwin-amd64 trust info riyaz/unsigned-img
Error: remote trust data does not exist for docker.io/riyaz/unsigned-img: notary.docker.io does not have trust data for docker.io/riyaz/unsigned-img
```

Some notes:
- output is displayed in sorted tag order (ascending alphabetically)
- signers are sorted alphabetically and joined by comma.  If there are no delegation signers, none are shown (see `alpine` output)
- if there aren't any signed tags, we display an error. It may make sense to instead display an empty table. Also note that the error messages should be revisited for better wording as part of `docker trust` (tracked in #10)
- for key/role data, we can reuse much of this pretty printing framework – we will need to define a new context and associated `*Write` function

cc @ashfall @eiais @endophage

<img src="http://r.fod4.com/c=sq/s=w1000,pd1/o=85/http://a.fod4.com/images/user_photos/1236179/5084aeb818cfaf4f7ab86883f34f2347_square_fullsize.png" width="400"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>