### PR TITLE
Pretty print signer info

### DIFF
--- a/cli/command/formatter/trust.go
+++ b/cli/command/formatter/trust.go
@@ -125,9 +125,8 @@ func (c *signerInfoContext) Keys() string {
 			truncatedKeys = append(truncatedKeys, stringid.TruncateID(keyID))
 		}
 		return strings.Join(truncatedKeys, ",")
-	} else {
-		return strings.Join(c.s.Keys, ",")
 	}
+	return strings.Join(c.s.Keys, ",")
 }
 
 // Signer returns the name of the signer

--- a/cli/command/formatter/trust.go
+++ b/cli/command/formatter/trust.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	defaultTrustTagTableFormat      = "table {{.SignedTag}}\t{{.Digest}}\t{{.Signers}}"
-	signedTagNameHeader             = "SIGNED TAG"
-	trustedDigestHeader             = "DIGEST"
-	signersHeader                   = "SIGNERS"
-	defaultSignerAndKeysTableFormat = "table {{.Signer}}\t{{.Keys}}"
-	signerNameHeader                = "SIGNER"
-	keysHeader                      = "KEYS"
+	defaultTrustTagTableFormat   = "table {{.SignedTag}}\t{{.Digest}}\t{{.Signers}}"
+	signedTagNameHeader          = "SIGNED TAG"
+	trustedDigestHeader          = "DIGEST"
+	signersHeader                = "SIGNERS"
+	defaultSignerInfoTableFormat = "table {{.Signer}}\t{{.Keys}}"
+	signerNameHeader             = "SIGNER"
+	keysHeader                   = "KEYS"
 )
 
 // SignedTagInfo represents all formatted information needed to describe a signed tag:
@@ -40,9 +40,9 @@ func NewTrustTagFormat() Format {
 	return defaultTrustTagTableFormat
 }
 
-// NewSignerAndKeysTableFormat returns a Format for rendering a signer role info Context
-func NewSignerAndKeysTableFormat() Format {
-	return defaultSignerAndKeysTableFormat
+// NewSignerInfoFormat returns a Format for rendering a signer role info Context
+func NewSignerInfoFormat() Format {
+	return defaultSignerInfoTableFormat
 }
 
 // TrustTagWrite writes the context

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -114,10 +114,10 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 	signerRoleToKeyIDs, adminRoleToKeyIDs := getSignerAndAdminRolesWithKeyIDs(roleWithSigs)
 
 	fmt.Fprintf(cli.Out(), "\nList of signers and their KeyIDs:\n\n")
-	printSignerAndKeys(cli, signerRoleToKeyIDs)
+	printSignerInfo(cli, signerRoleToKeyIDs)
 
 	fmt.Fprintf(cli.Out(), "\nList of admins and their KeyIDs:\n\n")
-	printSignerAndKeys(cli, adminRoleToKeyIDs)
+	printSignerInfo(cli, adminRoleToKeyIDs)
 
 	return nil
 }
@@ -191,10 +191,10 @@ func printSignatures(dockerCli command.Cli, signatureRows trustTagRowList) error
 	return formatter.TrustTagWrite(trustTagCtx, formattedTags)
 }
 
-func printSignerAndKeys(dockerCli command.Cli, roleToKeyIDs map[string][]string) error {
+func printSignerInfo(dockerCli command.Cli, roleToKeyIDs map[string][]string) error {
 	signerInfoCtx := formatter.Context{
 		Output: dockerCli.Out(),
-		Format: formatter.NewSignerAndKeysTableFormat(),
+		Format: formatter.NewSignerInfoFormat(),
 		Trunc:  true,
 	}
 	formattedSignerInfo := []formatter.SignerInfo{}

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -111,19 +111,19 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 		return trust.NotaryError(ref.Name(), err)
 	}
 
-	signerRoleToKeyIDs, adminRoleToKeyIDs := getSignerAndBaseRolesWithKeyIDs(roleWithSigs)
+	signerRoleToKeyIDs, adminRoleToKeyIDs := getSignerAndAdminRolesWithKeyIDs(roleWithSigs)
 
 	fmt.Fprintf(cli.Out(), "\nList of signers and their KeyIDs:\n\n")
-	printRolesWithKeyIDs(cli, signerRoleToKeyIDs)
+	printSignerAndKeys(cli, signerRoleToKeyIDs)
 
 	fmt.Fprintf(cli.Out(), "\nList of admins and their KeyIDs:\n\n")
-	printRolesWithKeyIDs(cli, adminRoleToKeyIDs)
+	printSignerAndKeys(cli, adminRoleToKeyIDs)
 
 	return nil
 }
 
 // Extract signer keys and admin keys from the list of roles
-func getSignerAndBaseRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) (map[string][]string, map[string][]string) {
+func getSignerAndAdminRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) (map[string][]string, map[string][]string) {
 	signerRoleToKeyIDs := make(map[string][]string)
 	adminRoleToKeyIDs := make(map[string][]string)
 
@@ -138,14 +138,6 @@ func getSignerAndBaseRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) (
 		}
 	}
 	return signerRoleToKeyIDs, adminRoleToKeyIDs
-}
-
-// Print signer keys and base keys from the list of roles
-func printRolesWithKeyIDs(cli command.Cli, roleToKeyIDs map[string][]string) {
-	fmt.Fprintf(cli.Out(), "Name \t\t\t KeyIDs\n")
-	for k, v := range roleToKeyIDs {
-		fmt.Fprintf(cli.Out(), "%s\t\t%v\n", k, v)
-	}
 }
 
 // aggregate all signers for a "released" hash+tagname pair. To be "released," the tag must have been
@@ -197,4 +189,20 @@ func printSignatures(dockerCli command.Cli, signatureRows trustTagRowList) error
 		})
 	}
 	return formatter.TrustTagWrite(trustTagCtx, formattedTags)
+}
+
+func printSignerAndKeys(dockerCli command.Cli, roleToKeyIDs map[string][]string) error {
+	signerInfoCtx := formatter.Context{
+		Output: dockerCli.Out(),
+		Format: formatter.NewSignerAndKeysTableFormat(),
+		Trunc:  true,
+	}
+	formattedSignerInfo := []formatter.SignerInfo{}
+	for name, keyIDs := range roleToKeyIDs {
+		formattedSignerInfo = append(formattedSignerInfo, formatter.SignerInfo{
+			Name: name,
+			Keys: keyIDs,
+		})
+	}
+	return formatter.SignerInfoWrite(signerInfoCtx, formattedSignerInfo)
 }

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -255,7 +255,7 @@ func TestMatchReleasedSignatureFromTargets(t *testing.T) {
 	assert.Equal(t, hex.EncodeToString(releasedTgt.Hashes[notary.SHA256]), outputRow.HashHex)
 }
 
-func TestGetSignerAndBaseRolesWithKeyIDs(t *testing.T) {
+func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 	roles := []data.Role{
 		{
 			RootRole: data.RootRole{
@@ -304,7 +304,7 @@ func TestGetSignerAndBaseRolesWithKeyIDs(t *testing.T) {
 		"alice": {"key11"},
 		"bob":   {"key71", "key72"},
 	}
-	expectedBaseRoleToKeyIDs := map[string][]string{
+	expectedAdminRoleToKeyIDs := map[string][]string{
 		"root":  {"key31"},
 		"admin": {"key41"},
 	}
@@ -314,7 +314,7 @@ func TestGetSignerAndBaseRolesWithKeyIDs(t *testing.T) {
 		roleWithSig := client.RoleWithSignatures{Role: role, Signatures: nil}
 		roleWithSigs = append(roleWithSigs, roleWithSig)
 	}
-	signerRoleToKeyIDs, baseRoleToKeyIDs := getSignerAndBaseRolesWithKeyIDs(roleWithSigs)
+	signerRoleToKeyIDs, baseRoleToKeyIDs := getSignerAndAdminRolesWithKeyIDs(roleWithSigs)
 	assert.Equal(t, signerRoleToKeyIDs, expectedSignerRoleToKeyIDs)
-	assert.Equal(t, baseRoleToKeyIDs, expectedBaseRoleToKeyIDs)
+	assert.Equal(t, baseRoleToKeyIDs, expectedAdminRoleToKeyIDs)
 }

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -314,7 +314,7 @@ func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 		roleWithSig := client.RoleWithSignatures{Role: role, Signatures: nil}
 		roleWithSigs = append(roleWithSigs, roleWithSig)
 	}
-	signerRoleToKeyIDs, baseRoleToKeyIDs := getSignerAndAdminRolesWithKeyIDs(roleWithSigs)
+	signerRoleToKeyIDs, adminRoleToKeyIDs := getSignerAndAdminRolesWithKeyIDs(roleWithSigs)
 	assert.Equal(t, signerRoleToKeyIDs, expectedSignerRoleToKeyIDs)
-	assert.Equal(t, baseRoleToKeyIDs, expectedAdminRoleToKeyIDs)
+	assert.Equal(t, adminRoleToKeyIDs, expectedAdminRoleToKeyIDs)
 }


### PR DESCRIPTION
Sample output:

```
$ ./build/docker-darwin-amd64 trust info linuxkit/dhcpcd
SIGNED TAG                                 DIGEST                                                             SIGNERS
17423c1ccced74e3c005fd80486e8177841fe02b   4354a7736e7c3b373dc62e3738e303ba5615a43d87f7603b0aad54d01faecb31   justin
4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41   ca28b47c87f2c9689d69820a5e6cb114189b2467b3abcee7629c6f4e62e113f2   justin
69e847d1ae066f6be83a81c86ea712fb20ee7891   d58cbb0e6da4974d30430470cf25b9ffde12ed2389e540e950123489a6240fb5   rolf
6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae   129a415917480edacc3751d0dbbcd9c27b21a0def79546e5c9945d872923e4ea   rolf
7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1   b1bef35accd165a4235ad301f9bef6544922cb6eafdb60268b05d8c9d0b1566b   justin
7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e   3c9b5f8b16dff4a5338f1db1eca61e90fb4e607bfb1b8addd1b05f084f0a68e0   rolf

List of signers and their KeyIDs:

SIGNER              KEYS
riyaz               54ec40e02fd0
rolf                2fb3dc88c284
ian                 82a66673242c
avi                 47caae5b3e61
ci                  74fc11c9c748
justin              b6f9f8e1aab0

List of admins and their KeyIDs:

SIGNER              KEYS
admin               43bdbe3ef420
root                2731adb1731a
```