### PR TITLE
trust info: test for headers on successful run

### DIFF
--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -77,6 +77,14 @@ func TestTrustInfo(t *testing.T) {
 		test.NewFakeCliWithOutput(&fakeClient{}, buf))
 	cmd.SetArgs([]string{"alpine"})
 	assert.NoError(t, cmd.Execute())
+
+	// Check for the signed tag headers
+	assert.Contains(t, buf.String(), "SIGNED TAG")
+	assert.Contains(t, buf.String(), "DIGEST")
+	assert.Contains(t, buf.String(), "SIGNERS")
+	// Check for the signer headers
+	assert.Contains(t, buf.String(), "SIGNER")
+	assert.Contains(t, buf.String(), "KEYS")
 }
 
 func TestTUFToSigner(t *testing.T) {


### PR DESCRIPTION
Test for existence of headers - don't test for actual values until we have a proper fixture (TBD if/how we do this)

![catwithhat](http://r.fod4.com/s=w800,pd1/o=85/http://a.fod4.com/images/user_photos/1236157/0bbd880af0c4125daaca367de3b65aae_original.jpg)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
