### PR TITLE
trust info: do not display empty signers table

### DIFF
--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -112,10 +112,13 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 	}
 
 	signerRoleToKeyIDs, adminRoleToKeyIDs := getSignerAndAdminRolesWithKeyIDs(roleWithSigs)
+	// If we do not have additional signers, do not display
+	if len(signerRoleToKeyIDs) > 0 {
+		fmt.Fprintf(cli.Out(), "\nList of signers and their KeyIDs:\n\n")
+		printSignerInfo(cli, signerRoleToKeyIDs)
+	}
 
-	fmt.Fprintf(cli.Out(), "\nList of signers and their KeyIDs:\n\n")
-	printSignerInfo(cli, signerRoleToKeyIDs)
-
+	// This will always have the root and targets information
 	fmt.Fprintf(cli.Out(), "\nList of admins and their KeyIDs:\n\n")
 	printSignerInfo(cli, adminRoleToKeyIDs)
 

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -83,6 +83,25 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
+	assert.Contains(t, buf.String(), "List of admins and their KeyIDs:")
+	assert.Contains(t, buf.String(), "SIGNER")
+	assert.Contains(t, buf.String(), "KEYS")
+	// no delegations on this repo
+	assert.NotContains(t, buf.String(), "List of signers and their KeyIDs:")
+
+	buf = new(bytes.Buffer)
+	cmd = newInfoCommand(
+		test.NewFakeCliWithOutput(&fakeClient{}, buf))
+	cmd.SetArgs([]string{"dockerorcadev/trust-fixture"})
+	assert.NoError(t, cmd.Execute())
+
+	// Check for the signed tag headers
+	assert.Contains(t, buf.String(), "SIGNED TAG")
+	assert.Contains(t, buf.String(), "DIGEST")
+	assert.Contains(t, buf.String(), "SIGNERS")
+	// Check for the signer headers
+	assert.Contains(t, buf.String(), "List of admins and their KeyIDs:")
+	assert.Contains(t, buf.String(), "List of signers and their KeyIDs:")
 	assert.Contains(t, buf.String(), "SIGNER")
 	assert.Contains(t, buf.String(), "KEYS")
 }


### PR DESCRIPTION
If there aren't any additional signers, don't show the table for it.  Example:
```
🐳 $ ./docker-darwin-amd64 trust info library/alpine
SIGNED TAG          DIGEST                                                             SIGNERS
2.6                 9ace551613070689a12857d62c30ef0daa9a376107ec0fff0e34786cedb3399b
2.7                 9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a
3.1                 d9477888b78e8c6392e0be8b2e73f8c67e2894ff9d4b8e467d1488fcceec21c8
3.2                 19826d59171c2eb7e90ce52bfd822993bef6a6fe3ae6bb4a49f8c1d0a01e99c7
3.3                 8fd4b76819e1e5baac82bd0a3d03abfe3906e034cc5ee32100d12aaaf3956dc7
3.4                 833ad81ace8277324f3ca8c91c02bdcf1d13988d8ecf8a3f97ecdd69d0390ce9
3.5                 af2a5bd2f8de8fc1ecabf1c76611cdc6a5f1ada1a2bdd7d3816e121b70300308
3.6                 1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
edge                79d50d15bd7ea48ea00cf3dd343b0e740c1afaa8e899bee475236ef338e1b53b
integ-test-base     3952dc48dcc4136ccdde37fbef7e250346538a55a0366e3fccc683336377e372
latest              1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe

List of admins and their KeyIDs:

SIGNER              KEYS
admin               5a46c9aaa82f
root                a2489bcac7a7
```

![image](https://user-images.githubusercontent.com/1865981/28853064-af29e644-76e2-11e7-8157-73757ba6e8de.png)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>


