### PR TITLE
Display admin and root keys as repository and pinning keys

### DIFF
--- a/cli/command/formatter/trust.go
+++ b/cli/command/formatter/trust.go
@@ -124,9 +124,9 @@ func (c *signerInfoContext) Keys() string {
 		for _, keyID := range c.s.Keys {
 			truncatedKeys = append(truncatedKeys, stringid.TruncateID(keyID))
 		}
-		return strings.Join(truncatedKeys, ",")
+		return strings.Join(truncatedKeys, ", ")
 	}
-	return strings.Join(c.s.Keys, ",")
+	return strings.Join(c.s.Keys, ", ")
 }
 
 // Signer returns the name of the signer

--- a/cli/command/formatter/trust_test.go
+++ b/cli/command/formatter/trust_test.go
@@ -202,9 +202,9 @@ func TestSignerInfoContextWrite(t *testing.T) {
 				Trunc:  true,
 			},
 			`SIGNER              KEYS
-alice               key11,key12
+alice               key11, key12
 bob                 key21
-eve                 foobarbazqux,key31,key32
+eve                 foobarbazqux, key31, key32
 `,
 		},
 		// No truncation
@@ -213,9 +213,9 @@ eve                 foobarbazqux,key31,key32
 				Format: NewSignerInfoFormat(),
 			},
 			`SIGNER              KEYS
-alice               key11,key12
+alice               key11, key12
 bob                 key21
-eve                 foobarbazquxquux,key31,key32
+eve                 foobarbazquxquux, key31, key32
 `,
 		},
 	}

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -119,23 +119,27 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 	}
 
 	// This will always have the root and targets information
-	fmt.Fprintf(cli.Out(), "\nList of admins and their KeyIDs:\n\n")
-	printSignerInfo(cli, adminRoleToKeyIDs)
+	fmt.Fprintf(cli.Out(), "\nRepository keys:\n\n")
+	for name, key := range adminRoleToKeyIDs {
+		fmt.Fprintf(cli.Out(), "%s:\t%s\n", name, key)
+	}
 
 	return nil
 }
 
 // Extract signer keys and admin keys from the list of roles
-func getSignerAndAdminRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) (map[string][]string, map[string][]string) {
+func getSignerAndAdminRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) (map[string][]string, map[string]string) {
 	signerRoleToKeyIDs := make(map[string][]string)
-	adminRoleToKeyIDs := make(map[string][]string)
+	adminRoleToKeyIDs := make(map[string]string)
 
 	for _, roleWithSig := range roleWithSigs {
 		switch roleWithSig.Name {
 		case trust.ReleasesRole, data.CanonicalSnapshotRole, data.CanonicalTimestampRole:
 			continue
-		case data.CanonicalRootRole, data.CanonicalTargetsRole:
-			adminRoleToKeyIDs[notaryRoleToSigner(roleWithSig.Name)] = roleWithSig.KeyIDs
+		case data.CanonicalRootRole:
+			adminRoleToKeyIDs["Administrative Key"] = roleWithSig.KeyIDs[0]
+		case data.CanonicalTargetsRole:
+			adminRoleToKeyIDs["Pinning Key"] = roleWithSig.KeyIDs[0]
 		default:
 			signerRoleToKeyIDs[notaryRoleToSigner(roleWithSig.Name)] = roleWithSig.KeyIDs
 		}

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -119,7 +119,7 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 	}
 
 	// This will always have the root and targets information
-	fmt.Fprintf(cli.Out(), "\nRepository keys:\n\n")
+	fmt.Fprintf(cli.Out(), "\nRepository keys for %s:\n", repoInfo.Name)
 	for name, key := range adminRoleToKeyIDs {
 		fmt.Fprintf(cli.Out(), "%s:\t%s\n", name, key)
 	}
@@ -137,9 +137,9 @@ func getSignerAndAdminRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) 
 		case trust.ReleasesRole, data.CanonicalSnapshotRole, data.CanonicalTimestampRole:
 			continue
 		case data.CanonicalRootRole:
-			adminRoleToKeyIDs["Administrative Key"] = roleWithSig.KeyIDs[0]
+			adminRoleToKeyIDs["Signer Admin Key"] = roleWithSig.KeyIDs[0]
 		case data.CanonicalTargetsRole:
-			adminRoleToKeyIDs["Pinning Key"] = roleWithSig.KeyIDs[0]
+			adminRoleToKeyIDs["Root Pinning Key"] = roleWithSig.KeyIDs[0]
 		default:
 			signerRoleToKeyIDs[notaryRoleToSigner(roleWithSig.Name)] = roleWithSig.KeyIDs
 		}

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -137,9 +137,9 @@ func getSignerAndAdminRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) 
 		case trust.ReleasesRole, data.CanonicalSnapshotRole, data.CanonicalTimestampRole:
 			continue
 		case data.CanonicalRootRole:
-			adminRoleToKeyIDs["Signer Admin Key"] = roleWithSig.KeyIDs[0]
+			adminRoleToKeyIDs["Signer Admin Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
 		case data.CanonicalTargetsRole:
-			adminRoleToKeyIDs["Root Pinning Key"] = roleWithSig.KeyIDs[0]
+			adminRoleToKeyIDs["Root Pinning Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
 		default:
 			signerRoleToKeyIDs[notaryRoleToSigner(roleWithSig.Name)] = roleWithSig.KeyIDs
 		}

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -83,7 +83,7 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
-	assert.Contains(t, buf.String(), "Repository keys:")
+	assert.Contains(t, buf.String(), "Repository keys for docker.io/library/alpine:")
 	// no delegations on this repo
 	assert.NotContains(t, buf.String(), "List of signers and their KeyIDs:")
 
@@ -101,7 +101,9 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "List of signers and their KeyIDs:")
 	assert.Contains(t, buf.String(), "SIGNER")
 	assert.Contains(t, buf.String(), "KEYS")
-	assert.Contains(t, buf.String(), "Repository keys:")
+	assert.Contains(t, buf.String(), "Repository keys for docker.io/dockerorcadev/trust-fixture:")
+	assert.Contains(t, buf.String(), "Signer Admin Key")
+	assert.Contains(t, buf.String(), "Root Pinning Key")
 }
 
 func TestTUFToSigner(t *testing.T) {
@@ -330,8 +332,8 @@ func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 		"bob":   {"key71", "key72"},
 	}
 	expectedAdminRoleToKeyIDs := map[string]string{
-		"Administrative Key": "key31",
-		"Pinning Key":        "key41",
+		"Signer Admin Key": "key31",
+		"Root Pinning Key": "key41",
 	}
 
 	var roleWithSigs []client.RoleWithSignatures

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -83,9 +83,7 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
-	assert.Contains(t, buf.String(), "List of admins and their KeyIDs:")
-	assert.Contains(t, buf.String(), "SIGNER")
-	assert.Contains(t, buf.String(), "KEYS")
+	assert.Contains(t, buf.String(), "Repository keys:")
 	// no delegations on this repo
 	assert.NotContains(t, buf.String(), "List of signers and their KeyIDs:")
 
@@ -100,10 +98,10 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
-	assert.Contains(t, buf.String(), "List of admins and their KeyIDs:")
 	assert.Contains(t, buf.String(), "List of signers and their KeyIDs:")
 	assert.Contains(t, buf.String(), "SIGNER")
 	assert.Contains(t, buf.String(), "KEYS")
+	assert.Contains(t, buf.String(), "Repository keys:")
 }
 
 func TestTUFToSigner(t *testing.T) {
@@ -331,9 +329,9 @@ func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 		"alice": {"key11"},
 		"bob":   {"key71", "key72"},
 	}
-	expectedAdminRoleToKeyIDs := map[string][]string{
-		"root":  {"key31"},
-		"admin": {"key41"},
+	expectedAdminRoleToKeyIDs := map[string]string{
+		"Administrative Key": "key31",
+		"Pinning Key":        "key41",
 	}
 
 	var roleWithSigs []client.RoleWithSignatures


### PR DESCRIPTION
Addresses a part of #23 

Example output:
```
List of signers and their KeyIDs:

SIGNER              KEYS
avi                 47caae5b3e61
ci                  74fc11c9c748
ian                 82a66673242c
justin              b6f9f8e1aab0
riyaz               54ec40e02fd0
rolf                2fb3dc88c284

Repository keys for docker.io/linuxkit/alpine:
Signer Admin Key:	3c4517d1f6ca6cb7da9fe7a1cdc0efdaef71ed3c398a9baed3ec0b05ee804c51
Root Pinning Key:	16cd3d73e5e75462bf337325c08e2b072ea3e658e8465aac0c09ea7f391fb6c8```