### PR TITLE
trust sign: add initialization code that also sets up signers

### DIFF
--- a/cli/command/trust/helpers.go
+++ b/cli/command/trust/helpers.go
@@ -1,0 +1,27 @@
+package trust
+
+import (
+	"context"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/registry"
+)
+
+func getImageReferencesAndAuth(cli command.Cli, imgName string) (reference.Named, *registry.RepositoryInfo, *types.AuthConfig, error) {
+	ref, err := reference.ParseNormalizedNamed(imgName)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Resolve the Repository name from fqn to RepositoryInfo
+	repoInfo, err := registry.ParseRepositoryInfo(ref)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	ctx := context.Background()
+	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
+	return ref, repoInfo, &authConfig, err
+}

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -1,7 +1,6 @@
 package trust
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 	"sort"
@@ -11,8 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/trust"
-	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/registry"
 	"github.com/docker/notary"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/tuf/data"
@@ -74,21 +71,12 @@ func newInfoCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func lookupTrustInfo(cli command.Cli, remote string) error {
-	ref, err := reference.ParseNormalizedNamed(remote)
+	ref, repoInfo, authConfig, err := getImageReferencesAndAuth(cli, remote)
 	if err != nil {
 		return err
 	}
 
-	// Resolve the Repository name from fqn to RepositoryInfo
-	repoInfo, err := registry.ParseRepositoryInfo(ref)
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
-
-	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, authConfig, "pull")
+	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, *authConfig, "pull")
 	if err != nil {
 		return trust.NotaryError(ref.Name(), err)
 	}

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -1,17 +1,106 @@
 package trust
 
 import (
+	"fmt"
+	"path"
+	"sort"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/trust"
+	"github.com/docker/notary/client"
+	"github.com/docker/notary/tuf/data"
 	"github.com/spf13/cobra"
 )
 
 func newSignCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "sign [OPTIONS]",
+		Use:   "sign [OPTIONS] IMAGE TAG",
 		Short: "Sign an image",
-		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		Args:  cli.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return signImage(dockerCli, args[0], args[1])
+		},
 	}
 	return cmd
+}
+
+func signImage(cli command.Cli, image, tag string) error {
+	ref, repoInfo, authConfig, err := getImageReferencesAndAuth(cli, image)
+	if err != nil {
+		return err
+	}
+
+	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, *authConfig, "push", "pull")
+	if err != nil {
+		return trust.NotaryError(ref.Name(), err)
+	}
+	fmt.Fprintf(cli.Out(), "Signing and pushing trust metadata for %s:%s\n", image, tag)
+
+	// get the latest repository metadata so we can figure out which roles to sign
+	if err = notaryRepo.Update(false); err != nil {
+		switch err.(type) {
+		case client.ErrRepoNotInitialized, client.ErrRepositoryNotExist:
+			userRole := data.RoleName(path.Join(data.CanonicalTargetsRole.String(), authConfig.Username))
+			if err := initNotaryRepoWithSigners(cli, notaryRepo, userRole); err != nil {
+				return trust.NotaryError(ref.Name(), err)
+			}
+			fmt.Fprintf(cli.Out(), "Created signer: %s\n", authConfig.Username)
+		default:
+			return trust.NotaryError(repoInfo.Name.Name(), err)
+		}
+	}
+
+	// TODO: craft and sign the target using image.addTargetToAllSignableRoles (needs to be exported)
+	return nil
+}
+
+func initNotaryRepoWithSigners(cli command.Cli, notaryRepo *client.NotaryRepository, newSigner data.RoleName) error {
+	keys := notaryRepo.CryptoService.ListKeys(data.CanonicalRootRole)
+	var err error
+	var rootKeyID string
+	// always select the first root key
+	if len(keys) > 0 {
+		sort.Strings(keys)
+		rootKeyID = keys[0]
+	} else {
+		rootPublicKey, err := notaryRepo.CryptoService.Create(data.CanonicalRootRole, "", data.ECDSAKey)
+		if err != nil {
+			return err
+		}
+		rootKeyID = rootPublicKey.ID()
+	}
+
+	// Initialize the notary repository with a remotely managed snapshot key
+	if err := notaryRepo.Initialize([]string{rootKeyID}, data.CanonicalSnapshotRole); err != nil {
+		return trust.NotaryError(notaryRepo.GetGUN().String(), err)
+	}
+
+	// Check if we have a user key
+	var signerKey data.PublicKey
+	signerKeys := notaryRepo.CryptoService.ListKeys(newSigner)
+	if len(signerKeys) > 0 {
+		sort.Strings(signerKeys)
+		signerKeyID := signerKeys[0]
+		signerKey = notaryRepo.CryptoService.GetKey(signerKeyID)
+	} else {
+		signerKey, err = notaryRepo.CryptoService.Create(newSigner, "", data.ECDSAKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	// create targets/<username>
+	notaryRepo.AddDelegationRoleAndKeys(newSigner, []data.PublicKey{signerKey})
+	notaryRepo.AddDelegationPaths(newSigner, []string{""})
+
+	// create targets/releases
+	notaryRepo.AddDelegationRoleAndKeys(trust.ReleasesRole, []data.PublicKey{signerKey})
+	notaryRepo.AddDelegationPaths(trust.ReleasesRole, []string{""})
+
+	if err := notaryRepo.Publish(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cli.Out(), "Finished initializing %q\n", notaryRepo.GetGUN().String())
+	return nil
 }

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -1,0 +1,55 @@
+package trust
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/pkg/testutil"
+)
+
+func TestTrustSignErrors(t *testing.T) {
+	testCases := []struct {
+		name          string
+		args          []string
+		expectedError string
+	}{
+		{
+			name:          "not-enough-args",
+			expectedError: "requires exactly 2 argument(s)",
+		}, {
+			name:          "still-not-enough-args",
+			args:          []string{"image"},
+			expectedError: "requires exactly 2 argument(s)",
+		},
+		{
+			name:          "too-many-args",
+			args:          []string{"image", "tag", "blah"},
+			expectedError: "requires exactly 2 argument(s)",
+		},
+		{
+			name:          "sha-reference",
+			args:          []string{"870d292919d01a0af7e7f056271dc78792c05f55f49b9b9012b6d89725bd9abd", "tag"},
+			expectedError: "invalid repository name",
+		},
+		{
+			name:          "nonexistent-reg",
+			args:          []string{"nonexistent-reg-name.io/image", "tag"},
+			expectedError: "no such host",
+		},
+		{
+			name:          "invalid-img-reference",
+			args:          []string{"ALPINE", "latest"},
+			expectedError: "invalid reference format",
+		},
+	}
+	for _, tc := range testCases {
+		buf := new(bytes.Buffer)
+		cmd := newSignCommand(
+			test.NewFakeCliWithOutput(&fakeClient{}, buf))
+		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+	}
+}

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -2,11 +2,22 @@ package trust
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/docker/notary"
+	"github.com/docker/notary/client/changelist"
+	"github.com/docker/notary/tuf/data"
+
 	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/cli/cli/trust"
 	"github.com/docker/docker/pkg/testutil"
+	"github.com/docker/notary/client"
+	"github.com/docker/notary/passphrase"
+	"github.com/docker/notary/trustpinning"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTrustSignErrors(t *testing.T) {
@@ -43,6 +54,11 @@ func TestTrustSignErrors(t *testing.T) {
 			args:          []string{"ALPINE", "latest"},
 			expectedError: "invalid reference format",
 		},
+		{
+			name:          "no-shell-for-passwd",
+			args:          []string{"riyaz/unsigned-img", "latest"},
+			expectedError: "maximum number of passphrase attempts exceeded",
+		},
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
@@ -52,4 +68,131 @@ func TestTrustSignErrors(t *testing.T) {
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
+}
+
+func TestGetOrGenerateNotaryKey(t *testing.T) {
+	passwd := "password"
+	tmpDir, err := ioutil.TempDir("", "notary-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	notaryRepo, err := client.NewFileCachedNotaryRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
+	assert.NoError(t, err)
+
+	// repo is empty, try making a root key
+	rootKeyA, err := getOrGenerateNotaryKey(notaryRepo, data.CanonicalRootRole)
+	assert.NoError(t, err)
+	assert.NotNil(t, rootKeyA)
+
+	// we should only have one newly generated key
+	allKeys := notaryRepo.CryptoService.ListAllKeys()
+	assert.Len(t, allKeys, 1)
+	assert.NotNil(t, notaryRepo.CryptoService.GetKey(rootKeyA.ID()))
+
+	// this time we should get back the same key if we ask for another root key
+	rootKeyB, err := getOrGenerateNotaryKey(notaryRepo, data.CanonicalRootRole)
+	assert.NoError(t, err)
+	assert.NotNil(t, rootKeyB)
+
+	// we should only have one newly generated key
+	allKeys = notaryRepo.CryptoService.ListAllKeys()
+	assert.Len(t, allKeys, 1)
+	assert.NotNil(t, notaryRepo.CryptoService.GetKey(rootKeyB.ID()))
+
+	// The key we retrieved should be identical to the one we generated
+	assert.Equal(t, rootKeyA, rootKeyB)
+
+	// Now also try with a delegation key
+	releasesKey, err := getOrGenerateNotaryKey(notaryRepo, data.RoleName(trust.ReleasesRole))
+	assert.NoError(t, err)
+	assert.NotNil(t, releasesKey)
+
+	// we should now have two keys
+	allKeys = notaryRepo.CryptoService.ListAllKeys()
+	assert.Len(t, allKeys, 2)
+	assert.NotNil(t, notaryRepo.CryptoService.GetKey(releasesKey.ID()))
+	// The key we retrieved should be identical to the one we generated
+	assert.NotEqual(t, releasesKey, rootKeyA)
+	assert.NotEqual(t, releasesKey, rootKeyB)
+}
+
+func TestAddStageSigners(t *testing.T) {
+	passwd := "password"
+	tmpDir, err := ioutil.TempDir("", "notary-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	notaryRepo, err := client.NewFileCachedNotaryRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
+	assert.NoError(t, err)
+
+	// stage targets/user
+	userRole := data.RoleName("targets/user")
+	userKey := data.NewPublicKey("algoA", []byte("a"))
+	addStagedSigner(notaryRepo, userRole, []data.PublicKey{userKey})
+	// check the changelist for four total changes: two on targets/releases and two on targets/user
+	cl, err := notaryRepo.GetChangelist()
+	assert.NoError(t, err)
+	changeList := cl.List()
+	assert.Len(t, changeList, 4)
+	// ordering is determinstic:
+
+	// first change is for targets/user key creation
+	newSignerKeyChange := changeList[0]
+	expectedJSON, err := json.Marshal(&changelist.TUFDelegation{
+		NewThreshold: notary.MinThreshold,
+		AddKeys:      data.KeyList([]data.PublicKey{userKey}),
+	})
+	expectedChange := changelist.NewTUFChange(
+		changelist.ActionCreate,
+		userRole,
+		changelist.TypeTargetsDelegation,
+		"", // no path for delegations
+		expectedJSON,
+	)
+	assert.Equal(t, expectedChange, newSignerKeyChange)
+
+	// second change is for targets/user getting all paths
+	newSignerPathsChange := changeList[1]
+	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
+		AddPaths: []string{""},
+	})
+	expectedChange = changelist.NewTUFChange(
+		changelist.ActionCreate,
+		userRole,
+		changelist.TypeTargetsDelegation,
+		"", // no path for delegations
+		expectedJSON,
+	)
+	assert.Equal(t, expectedChange, newSignerPathsChange)
+
+	releasesRole := data.RoleName("targets/releases")
+
+	// third change is for targets/releases key creation
+	releasesKeyChange := changeList[2]
+	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
+		NewThreshold: notary.MinThreshold,
+		AddKeys:      data.KeyList([]data.PublicKey{userKey}),
+	})
+	expectedChange = changelist.NewTUFChange(
+		changelist.ActionCreate,
+		releasesRole,
+		changelist.TypeTargetsDelegation,
+		"", // no path for delegations
+		expectedJSON,
+	)
+	assert.Equal(t, expectedChange, releasesKeyChange)
+
+	// fourth change is for targets/releases getting all paths
+	releasesPathsChange := changeList[3]
+	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
+		AddPaths: []string{""},
+	})
+	expectedChange = changelist.NewTUFChange(
+		changelist.ActionCreate,
+		releasesRole,
+		changelist.TypeTargetsDelegation,
+		"", // no path for delegations
+		expectedJSON,
+	)
+	assert.Equal(t, expectedChange, releasesPathsChange)
 }


### PR DESCRIPTION
This code:
- checks if a repo has been initialized
- if it hasn't, initializes a new notary repository (using an existing root key if one exists)
- ensures the snapshot key is handled by the server
- creates a signer for the `user`:
  - actual signer name taken from the docker username
  - creates `targets/<user>` and `targets/releases` roles
  - creates a new key for `user` if one doesn't exist and adds to those roles
- also creates a `helpers.go` to store helper functions that we should use across all subcommands

Follow-up: create an integration test in `integration-cli` for:
- happy case of initializing a brand new repo
- for an existing signed repo, ensure that new delegations aren't created

What it looks like on a fresh install:
```
riyaz@noir build 🐳 $ ./docker-darwin-amd64 trust sign riyaz/new-img tag
Signing and pushing trust metadata for riyaz/new-img:tag
You are about to create a new root signing key passphrase. This passphrase
will be used to protect the most sensitive key in your signing system. Please
choose a long, complex passphrase and be careful to keep the password and the
key file itself secure and backed up. It is highly recommended that you use a
password manager to generate the passphrase and keep it safe. There will be no
way to recover this key. You can find the key in your config directory.
Enter passphrase for new root key with ID 557f5ec:
Repeat passphrase for new root key with ID 557f5ec:
Enter passphrase for new repository key with ID cd21e70:
Repeat passphrase for new repository key with ID cd21e70:
Enter passphrase for new targets/riyaz key with ID 9b86cc9:
Repeat passphrase for new targets/riyaz key with ID 9b86cc9:
Created signer: riyaz
Finished initializing "docker.io/riyaz/new-img"
riyaz@noir build 🐳 $
riyaz@noir build 🐳 $ notary -s https://notary.docker.io delegation list docker.io/riyaz/new-img
Enter username: riyaz
Enter password:

ROLE                PATHS             KEY IDS                                                             THRESHOLD
----                -----             -------                                                             ---------
targets/releases    "" <all paths>    9b86cc967a664fa4bff99b3d5ff35d91d0e48d1988bc7be67eb2cac2ea4e8453    1
targets/riyaz       "" <all paths>    9b86cc967a664fa4bff99b3d5ff35d91d0e48d1988bc7be67eb2cac2ea4e8453    1
```

Closes #14