### PR TITLE
Add default signer name

### DIFF
--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -199,10 +199,14 @@ func printSignatures(dockerCli command.Cli, signatureRows trustTagRowList) error
 	// convert the formatted type before printing
 	formattedTags := []formatter.SignedTagInfo{}
 	for _, sigRow := range signatureRows {
+		formattedSigners := sigRow.Signers
+		if len(formattedSigners) == 0 {
+			formattedSigners = append(formattedSigners, "(Repo Admin)")
+		}
 		formattedTags = append(formattedTags, formatter.SignedTagInfo{
 			Name:    sigRow.TagName,
 			Digest:  sigRow.HashHex,
-			Signers: sigRow.Signers,
+			Signers: formattedSigners,
 		})
 	}
 	return formatter.TrustTagWrite(trustTagCtx, formattedTags)

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -84,6 +84,7 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
 	assert.Contains(t, buf.String(), "Repository keys for docker.io/library/alpine:")
+	assert.Contains(t, buf.String(), "(Repo Admin)")
 	// no delegations on this repo
 	assert.NotContains(t, buf.String(), "List of signers and their KeyIDs:")
 
@@ -96,10 +97,9 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
-	assert.Contains(t, buf.String(), "List of admins and their KeyIDs:")
-	assert.Contains(t, buf.String(), "SIGNER")
-	assert.Contains(t, buf.String(), "KEYS")
+	assert.Contains(t, buf.String(), "Repository keys for docker.io/library/alpine:")
 	assert.Contains(t, buf.String(), "3.5")
+	assert.Contains(t, buf.String(), "(Repo Admin)")
 	// no delegations on this repo
 	assert.NotContains(t, buf.String(), "3.6")
 	assert.NotContains(t, buf.String(), "List of signers and their KeyIDs:")
@@ -121,6 +121,8 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "Repository keys for docker.io/dockerorcadev/trust-fixture:")
 	assert.Contains(t, buf.String(), "Signer Admin Key")
 	assert.Contains(t, buf.String(), "Root Pinning Key")
+	// all signers have names
+	assert.NotContains(t, buf.String(), "(Repo Admin)")
 }
 
 func TestTUFToSigner(t *testing.T) {


### PR DESCRIPTION
(Repo Admin) shows up instead of a blank line

![](https://i.pinimg.com/736x/c0/a4/c1/c0a4c1cd8ca4140901f2d5500b03bfad---years-old-year-old.jpg)
