### PR TITLE
docker trust info: key matching and verbiage cleanup

### DIFF
--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -120,7 +120,7 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 	}
 
 	// This will always have the root and targets information
-	fmt.Fprintf(cli.Out(), "\nRepository keys for %s:\n", repoInfo.Name)
+	fmt.Fprintf(cli.Out(), "\nAdministrative keys for %s:\n", repoInfo.Name)
 	for name, key := range adminRoleToKeyIDs {
 		fmt.Fprintf(cli.Out(), "%s:\t%s\n", name, key)
 	}
@@ -138,9 +138,9 @@ func getSignerAndAdminRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) 
 		case trust.ReleasesRole, data.CanonicalSnapshotRole, data.CanonicalTimestampRole:
 			continue
 		case data.CanonicalTargetsRole:
-			adminRoleToKeyIDs["Signer Admin Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
+			adminRoleToKeyIDs["Repository Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
 		case data.CanonicalRootRole:
-			adminRoleToKeyIDs["Root Pinning Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
+			adminRoleToKeyIDs["Root Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
 		default:
 			signerRoleToKeyIDs[notaryRoleToSigner(roleWithSig.Name)] = roleWithSig.KeyIDs
 		}

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -137,9 +137,9 @@ func getSignerAndAdminRolesWithKeyIDs(roleWithSigs []client.RoleWithSignatures) 
 		switch roleWithSig.Name {
 		case trust.ReleasesRole, data.CanonicalSnapshotRole, data.CanonicalTimestampRole:
 			continue
-		case data.CanonicalRootRole:
-			adminRoleToKeyIDs["Signer Admin Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
 		case data.CanonicalTargetsRole:
+			adminRoleToKeyIDs["Signer Admin Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
+		case data.CanonicalRootRole:
 			adminRoleToKeyIDs["Root Pinning Key"] = strings.Join(roleWithSig.KeyIDs, ", ")
 		default:
 			signerRoleToKeyIDs[notaryRoleToSigner(roleWithSig.Name)] = roleWithSig.KeyIDs

--- a/cli/command/trust/info.go
+++ b/cli/command/trust/info.go
@@ -120,7 +120,7 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 	}
 
 	// This will always have the root and targets information
-	fmt.Fprintf(cli.Out(), "\nAdministrative keys for %s:\n", repoInfo.Name)
+	fmt.Fprintf(cli.Out(), "\nAdministrative keys for %s:\n", remote)
 	for name, key := range adminRoleToKeyIDs {
 		fmt.Fprintf(cli.Out(), "%s:\t%s\n", name, key)
 	}

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -313,13 +313,13 @@ func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 			RootRole: data.RootRole{
 				KeyIDs: []string{"key31"},
 			},
-			Name: data.CanonicalRootRole,
+			Name: data.CanonicalTargetsRole,
 		},
 		{
 			RootRole: data.RootRole{
 				KeyIDs: []string{"key41"},
 			},
-			Name: data.CanonicalTargetsRole,
+			Name: data.CanonicalRootRole,
 		},
 		{
 			RootRole: data.RootRole{

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -83,7 +83,7 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
-	assert.Contains(t, buf.String(), "Repository keys for docker.io/library/alpine:")
+	assert.Contains(t, buf.String(), "Administrative keys for docker.io/library/alpine:")
 	assert.Contains(t, buf.String(), "(Repo Admin)")
 	// no delegations on this repo
 	assert.NotContains(t, buf.String(), "List of signers and their KeyIDs:")
@@ -97,7 +97,7 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
-	assert.Contains(t, buf.String(), "Repository keys for docker.io/library/alpine:")
+	assert.Contains(t, buf.String(), "Administrative keys for docker.io/library/alpine:")
 	assert.Contains(t, buf.String(), "3.5")
 	assert.Contains(t, buf.String(), "(Repo Admin)")
 	// no delegations on this repo
@@ -118,9 +118,9 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "List of signers and their KeyIDs:")
 	assert.Contains(t, buf.String(), "SIGNER")
 	assert.Contains(t, buf.String(), "KEYS")
-	assert.Contains(t, buf.String(), "Repository keys for docker.io/dockerorcadev/trust-fixture:")
-	assert.Contains(t, buf.String(), "Signer Admin Key")
-	assert.Contains(t, buf.String(), "Root Pinning Key")
+	assert.Contains(t, buf.String(), "Administrative keys for docker.io/dockerorcadev/trust-fixture:")
+	assert.Contains(t, buf.String(), "Repository Key")
+	assert.Contains(t, buf.String(), "Root Key")
 	// all signers have names
 	assert.NotContains(t, buf.String(), "(Repo Admin)")
 }
@@ -345,8 +345,8 @@ func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 		"bob":   {"key71", "key72"},
 	}
 	expectedAdminRoleToKeyIDs := map[string]string{
-		"Signer Admin Key": "key31",
-		"Root Pinning Key": "key41",
+		"Root Key":       "key41",
+		"Repository Key": "key31",
 	}
 
 	var roleWithSigs []client.RoleWithSignatures

--- a/cli/command/trust/info_test.go
+++ b/cli/command/trust/info_test.go
@@ -83,7 +83,7 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
-	assert.Contains(t, buf.String(), "Administrative keys for docker.io/library/alpine:")
+	assert.Contains(t, buf.String(), "Administrative keys for alpine:")
 	assert.Contains(t, buf.String(), "(Repo Admin)")
 	// no delegations on this repo
 	assert.NotContains(t, buf.String(), "List of signers and their KeyIDs:")
@@ -97,7 +97,7 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "DIGEST")
 	assert.Contains(t, buf.String(), "SIGNERS")
 	// Check for the signer headers
-	assert.Contains(t, buf.String(), "Administrative keys for docker.io/library/alpine:")
+	assert.Contains(t, buf.String(), "Administrative keys for alpine:")
 	assert.Contains(t, buf.String(), "3.5")
 	assert.Contains(t, buf.String(), "(Repo Admin)")
 	// no delegations on this repo
@@ -118,7 +118,7 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, buf.String(), "List of signers and their KeyIDs:")
 	assert.Contains(t, buf.String(), "SIGNER")
 	assert.Contains(t, buf.String(), "KEYS")
-	assert.Contains(t, buf.String(), "Administrative keys for docker.io/dockerorcadev/trust-fixture:")
+	assert.Contains(t, buf.String(), "Administrative keys for dockerorcadev/trust-fixture:")
 	assert.Contains(t, buf.String(), "Repository Key")
 	assert.Contains(t, buf.String(), "Root Key")
 	// all signers have names


### PR DESCRIPTION
from feedback during today's sync:
- the root key and targets key had swapped IDs
- "Administrative keys" instead of "Repository keys"
- print the user supplied name (`alpine`) instead of fully-qualified name (`docker.io/library/alpine`)
- "Root Pinning Key" -> "Root Key" for consistency
- "Signer Admin Key" -> "Repository Key" for consistency

```
🐳 $ ./docker-darwin-amd64 trust info linuxkit/dhcpcd
SIGNED TAG                                       DIGEST                                                             SIGNERS
17423c1ccced74e3c005fd80486e8177841fe02b         4354a7736e7c3b373dc62e3738e303ba5615a43d87f7603b0aad54d01faecb31   justin
4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41         ca28b47c87f2c9689d69820a5e6cb114189b2467b3abcee7629c6f4e62e113f2   justin
69e847d1ae066f6be83a81c86ea712fb20ee7891         d58cbb0e6da4974d30430470cf25b9ffde12ed2389e540e950123489a6240fb5   rolf
6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae         129a415917480edacc3751d0dbbcd9c27b21a0def79546e5c9945d872923e4ea   rolf
7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1         b1bef35accd165a4235ad301f9bef6544922cb6eafdb60268b05d8c9d0b1566b   justin
7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e         3c9b5f8b16dff4a5338f1db1eca61e90fb4e607bfb1b8addd1b05f084f0a68e0   rolf
f3f5413abb78fae9020e35bd4788fa93df4530b7         3f5cafe744b719ab45f1515174387859d647f387dc79b0956e8a983ed04d3da4   (Repo Admin)
f3f5413abb78fae9020e35bd4788fa93df4530b7-amd64   80716ec5693c8d62950d54a2d70b3c3dbbc66493cdb948ed7b3b0168371f60f3   rolf
f3f5413abb78fae9020e35bd4788fa93df4530b7-arm64   6d9aa353d99d5def7bf153a252e362e67dc2cda59b69379cac286c5f3f264402   rolf

List of signers and their KeyIDs:

SIGNER              KEYS
avi                 47caae5b3e61, a85aab9d20a4
ci                  74fc11c9c748
ian                 034370bcbd77, 82a66673242c
justin              b6f9f8e1aab0
riyaz               54ec40e02fd0
rolf                2fb3dc88c284

Administrative keys for linuxkit/dhcpcd:
Root Key:	2731adb1731af9d3566fc2775da4b928f8a322a01a76f50fecab4462765e877d
Repository Key:	43bdbe3ef4208934665ca98bc8b7b32fabcc4978344e7195d5eff2b088cb52a7
```

![catswithhats](https://media.giphy.com/media/KTyJ3VPxkbDKU/giphy.gif)