### PR TITLE
docker trust inspect: better empty case, update docs

### DIFF
--- a/cli/command/trust/inspect.go
+++ b/cli/command/trust/inspect.go
@@ -81,8 +81,12 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 		}
 	}
 	signatureRows := matchReleasedSignatures(allSignedTargets)
-	if err := printSignatures(cli, signatureRows); err != nil {
-		return err
+	if len(signatureRows) > 0 {
+		if err := printSignatures(cli, signatureRows); err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintf(cli.Out(), "\nNo signatures for %s\n\n", remote)
 	}
 
 	roleWithSigs, err := notaryRepo.ListRoles()

--- a/cli/command/trust/inspect_test.go
+++ b/cli/command/trust/inspect_test.go
@@ -118,6 +118,26 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, cli.OutBuffer().String(), "Root Key")
 	// all signers have names
 	assert.NotContains(t, cli.OutBuffer().String(), "(Repo Admin)")
+
+	cli = test.NewFakeCli(&fakeClient{})
+	cmd = newInspectCommand(cli)
+	cmd.SetArgs([]string{"dockerorcadev/trust-fixture:unsigned"})
+	assert.NoError(t, cmd.Execute())
+
+	// Check that the signatures table does not show up, and instead we get the message
+	assert.Contains(t, cli.OutBuffer().String(), "No signatures for dockerorcadev/trust-fixture:unsigned")
+	assert.NotContains(t, cli.OutBuffer().String(), "SIGNED TAG")
+	assert.NotContains(t, cli.OutBuffer().String(), "DIGEST")
+	assert.NotContains(t, cli.OutBuffer().String(), "SIGNERS")
+	// Check for the signer headers
+	assert.Contains(t, cli.OutBuffer().String(), "List of signers and their KeyIDs:")
+	assert.Contains(t, cli.OutBuffer().String(), "SIGNER")
+	assert.Contains(t, cli.OutBuffer().String(), "KEYS")
+	assert.Contains(t, cli.OutBuffer().String(), "Administrative keys for dockerorcadev/trust-fixture:")
+	assert.Contains(t, cli.OutBuffer().String(), "Repository Key")
+	assert.Contains(t, cli.OutBuffer().String(), "Root Key")
+	// all signers have names
+	assert.NotContains(t, cli.OutBuffer().String(), "(Repo Admin)")
 }
 
 func TestTUFToSigner(t *testing.T) {

--- a/docs/reference/commandline/trust_inspect.md
+++ b/docs/reference/commandline/trust_inspect.md
@@ -68,6 +68,24 @@ Repository Key:	27df2c8187e7543345c2e0bf3a1262e0bc63a72754e9a7395eac3f747ec23a44
 Root Key:	40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f
 ```
 
+If the image tag is unsigned or unavailable, `docker trust inspect` will not display any signed tags.
+```
+$ docker trust inspect unsigned-img
+No signatures or cannot access unsigned-img
+```
+
+However, if other tags are signed in the same image repository, `docker trust inspect` will report relevant key information.
+```
+$ docker trust inspect alpine:unsigned
+
+No signatures for alpine:unsigned
+
+
+Administrative keys for alpine:unsigned:
+Repository Key:	5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd
+Root Key:	a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce
+```
+
 ### Get details about signatures for all image tags in a repository
 
 ```bash

--- a/docs/reference/commandline/trust_revoke.md
+++ b/docs/reference/commandline/trust_revoke.md
@@ -46,8 +46,8 @@ blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e37
 List of signers and their KeyIDs:
 
 SIGNER              KEYS
-alice             05e87edcaecb
-bob               5600f5ab76a2
+alice               05e87edcaecb
+bob                 5600f5ab76a2
 
 Administrative keys for example/trust-demo:
 Root Key:	3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
@@ -72,8 +72,8 @@ blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e37
 List of signers and their KeyIDs:
 
 SIGNER              KEYS
-alice             05e87edcaecb
-bob               5600f5ab76a2
+alice               05e87edcaecb
+bob                 5600f5ab76a2
 
 Administrative keys for example/trust-demo:
 Root Key:	3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
@@ -93,8 +93,8 @@ blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e37
 List of signers and their KeyIDs:
 
 SIGNER              KEYS
-alice             05e87edcaecb
-bob               5600f5ab76a2
+alice               05e87edcaecb
+bob                 5600f5ab76a2
 
 Administrative keys for example/trust-demo:
 Root Key:	3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
@@ -114,13 +114,15 @@ the all tags that have alice's signature on them get removed from the list of re
 
 ```bash
 $ docker trust inspect example/trust-demo
-SIGNED TAG          DIGEST                                                              SIGNERS
+
+No signatures for example/trust-demo
+
 
 List of signers and their KeyIDs:
 
 SIGNER              KEYS
-alice             05e87edcaecb
-bob               5600f5ab76a2
+alice               05e87edcaecb
+bob                 5600f5ab76a2
 
 Administrative keys for example/trust-demo:
 Root Key:	3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949


### PR DESCRIPTION
instead of an empty table, show a better message if a repo has been initialized but has no signed tags:

```
🐳 $ ./docker-darwin-amd64 trust inspect alpine:unsigned

No signatures for alpine:unsigned


Administrative keys for alpine:unsigned:
Repository Key:	5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd
Root Key:	a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce
```

cc @ashfall @eiais 

![](https://i.pinimg.com/736x/48/9c/56/489c565c632aebdb81d5e356df8658b1--crochet-cat-clothes-cat-hat-crochet.jpg)