### PR TITLE
Flesh out examples for `docker trust revoke`

### DIFF
--- a/docs/reference/commandline/trust_revoke.md
+++ b/docs/reference/commandline/trust_revoke.md
@@ -20,6 +20,10 @@ Usage:  docker trust revoke [OPTIONS] IMAGE[:TAG]
 
 Remove trust for an image
 
+Options:
+      --help   Print usage
+  -y, --yes    Answer yes to the removal question (no confirmation)
+
 ```
 
 ## Description
@@ -30,13 +34,96 @@ Docker trust revoke removes signatures from tags in signed repositories.
 
 ### Revoke signatures from a signed tag
 
+Here's an example of a repo with two signed tags:
+
+
 ```bash
-$ docker trust revoke alpine:latest
+$ docker trust inspect example/trust-demo
+SIGNED TAG          DIGEST                                                              SIGNERS
+red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
+blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
+
+List of signers and their KeyIDs:
+
+SIGNER              KEYS
+alice             05e87edcaecb
+bob               5600f5ab76a2
+
+Administrative keys for example/trust-demo:
+Root Key:	3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+Repository Key:	ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+```
+
+When alice runs `docker trust revoke`  like so:
+
+```bash
+$ docker trust revoke example/trust-demo:red
+Enter passphrase for delegation key with ID 27d42a8:
+Successfully deleted signature for example/trust-demo:red
+```
+
+the said tag gets removed from the list of released tags:
+
+```bash
+$ docker trust inspect example/trust-demo
+SIGNED TAG          DIGEST                                                              SIGNERS
+blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
+
+List of signers and their KeyIDs:
+
+SIGNER              KEYS
+alice             05e87edcaecb
+bob               5600f5ab76a2
+
+Administrative keys for example/trust-demo:
+Root Key:	3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+Repository Key:	ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
 ```
 
 ### Revoke signatures on all tags in a repository
 
+When no tag is specified, `docker trust` revokes all signatures that you have a signing key for.
+
 ```bash
-$ docker trust revoke alpine
+$ docker trust inspect example/trust-demo
+SIGNED TAG          DIGEST                                                              SIGNERS
+red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
+blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
+
+List of signers and their KeyIDs:
+
+SIGNER              KEYS
+alice             05e87edcaecb
+bob               5600f5ab76a2
+
+Administrative keys for example/trust-demo:
+Root Key:	3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+Repository Key:	ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+```
+
+When alice runs `docker trust revoke`  like so:
+
+```bash
+$ docker trust revoke example/trust-demo
+Please confirm you would like to delete all signature data for example/trust-demo? (y/n) y
+Enter passphrase for delegation key with ID 27d42a8:
+Successfully deleted signature for example/trust-demo
+```
+
+the all tags that have alice's signature on them get removed from the list of released tags:
+
+```bash
+$ docker trust inspect example/trust-demo
+SIGNED TAG          DIGEST                                                              SIGNERS
+
+List of signers and their KeyIDs:
+
+SIGNER              KEYS
+alice             05e87edcaecb
+bob               5600f5ab76a2
+
+Administrative keys for example/trust-demo:
+Root Key:	3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+Repository Key:	ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
 ```
 


### PR DESCRIPTION
Illustrating the `trust revoke` command with examples using `docker trust inspect`

![image](https://user-images.githubusercontent.com/1138873/29589635-d40d3574-874a-11e7-9c7b-9e9a84817a13.png)
