### PR TITLE
docker trust sign: check local image cache before initializing notary repo

### DIFF
--- a/cli/command/trust/helpers.go
+++ b/cli/command/trust/helpers.go
@@ -14,6 +14,11 @@ import (
 	"github.com/docker/notary/tuf/data"
 )
 
+func checkLocalImageExistence(ctx context.Context, cli command.Cli, imageName string) error {
+	_, _, err := cli.Client().ImageInspectWithRaw(ctx, imageName)
+	return err
+}
+
 func getImageReferencesAndAuth(cli command.Cli, imgName string) (context.Context, reference.Named, *registry.RepositoryInfo, *types.AuthConfig, error) {
 	ref, err := reference.ParseNormalizedNamed(imgName)
 	if err != nil {

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -1,7 +1,6 @@
 package trust
 
 import (
-	"context"
 	"fmt"
 	"path"
 	"sort"
@@ -89,11 +88,6 @@ func signImage(cli command.Cli, imageName string) error {
 	}
 	fmt.Fprintf(cli.Out(), "Successfully signed %q:%s\n", repoInfo.Name.Name(), tag)
 	return nil
-}
-
-func checkLocalImageExistence(ctx context.Context, cli command.Cli, imageName string) error {
-	_, _, err := cli.Client().ImageInspectWithRaw(ctx, imageName)
-	return err
 }
 
 func createTarget(notaryRepo *client.NotaryRepository, tag string) (client.Target, error) {

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -1,6 +1,7 @@
 package trust
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"sort"
@@ -50,6 +51,11 @@ func signImage(cli command.Cli, imageName string) error {
 	if err = notaryRepo.Update(false); err != nil {
 		switch err.(type) {
 		case client.ErrRepoNotInitialized, client.ErrRepositoryNotExist:
+			// before initializing a new repo, check that the image exists locally:
+			if err := checkLocalImageExistence(ctx, cli, imageName); err != nil {
+				return err
+			}
+
 			userRole := data.RoleName(path.Join(data.CanonicalTargetsRole.String(), authConfig.Username))
 			if err := initNotaryRepoWithSigners(notaryRepo, userRole); err != nil {
 				return trust.NotaryError(ref.Name(), err)
@@ -83,6 +89,11 @@ func signImage(cli command.Cli, imageName string) error {
 	}
 	fmt.Fprintf(cli.Out(), "Successfully signed %q:%s\n", repoInfo.Name.Name(), tag)
 	return nil
+}
+
+func checkLocalImageExistence(ctx context.Context, cli command.Cli, imageName string) error {
+	_, _, err := cli.Client().ImageInspectWithRaw(ctx, imageName)
+	return err
 }
 
 func createTarget(notaryRepo *client.NotaryRepository, tag string) (client.Target, error) {

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -54,7 +54,7 @@ func TestTrustSignErrors(t *testing.T) {
 		{
 			name:          "no-shell-for-passwd",
 			args:          []string{"riyaz/unsigned-img:latest"},
-			expectedError: "maximum number of passphrase attempts exceeded",
+			expectedError: "error during connect: Get /images/riyaz/unsigned-img:latest/json",
 		},
 		{
 			name:          "no-tag",


### PR DESCRIPTION
Confirmed that this is a proper way to check if a local image exists with docker/cli folks.  We'll want a better integration test once the framework is in place.

Closes #60 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>

![](http://wishingonsuns.weebly.com/uploads/4/6/7/0/46701719/4778692_orig.jpg)
