### PR TITLE
docker trust inspect: get canonical key ids for delegations

### DIFF
--- a/cli/command/trust/helpers.go
+++ b/cli/command/trust/helpers.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/notary/tuf/data"
 )
 
+const releasedRoleName = "Repo Admin"
+
 func checkLocalImageExistence(ctx context.Context, cli command.Cli, imageName string) error {
 	_, _, err := cli.Client().ImageInspectWithRaw(ctx, imageName)
 	return err

--- a/cli/command/trust/inspect_test.go
+++ b/cli/command/trust/inspect_test.go
@@ -332,7 +332,7 @@ func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 		},
 		{
 			RootRole: data.RootRole{
-				KeyIDs: []string{"key41"},
+				KeyIDs: []string{"key41", "key01"},
 			},
 			Name: data.CanonicalRootRole,
 		},
@@ -360,7 +360,7 @@ func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 		"bob":   {"key71", "key72"},
 	}
 	expectedAdminRoleToKeyIDs := map[string]string{
-		"Root Key":       "key41",
+		"Root Key":       "key01, key41",
 		"Repository Key": "key31",
 	}
 
@@ -369,7 +369,8 @@ func TestGetSignerAndAdminRolesWithKeyIDs(t *testing.T) {
 		roleWithSig := client.RoleWithSignatures{Role: role, Signatures: nil}
 		roleWithSigs = append(roleWithSigs, roleWithSig)
 	}
-	signerRoleToKeyIDs, adminRoleToKeyIDs := getSignerAndAdminRolesWithKeyIDs(roleWithSigs)
-	assert.Equal(t, signerRoleToKeyIDs, expectedSignerRoleToKeyIDs)
-	assert.Equal(t, adminRoleToKeyIDs, expectedAdminRoleToKeyIDs)
+	signerRoleToKeyIDs := getDelegationRoleToKeyMap(roles)
+	assert.Equal(t, expectedSignerRoleToKeyIDs, signerRoleToKeyIDs)
+	adminRoleToKeyIDs := getAdministrativeRolesToKeyMap(roleWithSigs)
+	assert.Equal(t, expectedAdminRoleToKeyIDs, adminRoleToKeyIDs)
 }


### PR DESCRIPTION
For backwards compatibility, especially with UCP client bundles that make use of certs for delegation keys, use canonical key ids (given by `GetDelegationRoles`) when printing signers.

Also: renames `admin` to `Repo Admin`, and enforces that administrative key IDs are sorted if multiple are printed.

cc @ashfall @eiais 

Closes #64 

![](https://i.pinimg.com/236x/6d/f5/be/6df5beb31e85f05ba06edf49ddcef510.jpg)


Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
