### PR TITLE
Fix double erroring

### DIFF
--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -91,8 +91,7 @@ func signImage(cli command.Cli, imageName string) error {
 		err = notaryRepo.Publish()
 	}
 	if err != nil {
-		fmt.Fprintf(cli.Out(), "Failed to sign %q:%s - %s\n", repoInfo.Name.Name(), tag, err.Error())
-		return trust.NotaryError(repoInfo.Name.Name(), err)
+		return fmt.Errorf("failed to sign %q:%s - %s", repoInfo.Name.Name(), tag, err.Error())
 	}
 	fmt.Fprintf(cli.Out(), "Successfully signed %q:%s\n", repoInfo.Name.Name(), tag)
 	return nil

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -68,6 +68,11 @@ func TestTrustSignErrors(t *testing.T) {
 			args:          []string{"ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"},
 			expectedError: "cannot use a digest reference for IMAGE:TAG",
 		},
+		{
+			name:          "no-keys",
+			args:          []string{"ubuntu:latest"},
+			expectedError: "failed to sign \"docker.io/library/ubuntu\":latest - you are not authorized to perform this operation: server returned 401.",
+		},
 	}
 	// change to a tmpdir
 	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")


### PR DESCRIPTION
Fixed the double errors. Confirmed command still exits with the right status code.
But the error changed, still looking into that

Signed-off-by: Kyle Spiers <kyle@spiers.me>
![](https://www.iizcat.com/uploads/2017/04/ov48y-cb2.jpg)