### PR TITLE
use signer name for cryptoservice key generation and lookup

### DIFF
--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -158,6 +158,10 @@ func initNotaryRepoWithSigners(notaryRepo *client.NotaryRepository, newSigner da
 
 // generates an ECDSA key without a GUN for the specified role
 func getOrGenerateNotaryKey(notaryRepo *client.NotaryRepository, role data.RoleName) (data.PublicKey, error) {
+	// use the signer name in the PEM headers if this is a delegation key
+	if data.IsDelegation(role) {
+		role = data.RoleName(notaryRoleToSigner(role))
+	}
 	keys := notaryRepo.CryptoService.ListKeys(role)
 	var err error
 	var key data.PublicKey


### PR DESCRIPTION
Instead of allowing for output like:
```
Enter passphrase for targets/riyaz key with ID 3cfa79d:
```

Will generate and lookup keys as follows:
```
Enter passphrase for riyaz key with ID 97bc6c9:
```

Closes #67 

<img src="https://sharesloth.com/wp-content/uploads/2014/03/miserable-cat-with-hat.jpg" width="400"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>