### PR TITLE
trust sign: fix import

### DIFF
--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -1,6 +1,7 @@
 package trust
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -275,5 +276,4 @@ func TestPrintOtherSigners(t *testing.T) {
 	os.Stdout = old
 	out := <-outC
 	assert.EqualValues(t, "Other signers of this tag:\nAlice, Bob, Carol\n", out)
-
 }


### PR DESCRIPTION
contentious merge sequence dropped an import.


![](https://kittybloger.files.wordpress.com/2012/05/cats-in-the-hats-15-amazing-pictures-2.jpg)


Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
