### PR TITLE
trust info: drop the tag for admin key printing

### DIFF
--- a/cli/command/trust/inspect.go
+++ b/cli/command/trust/inspect.go
@@ -108,7 +108,7 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 	}
 
 	// This will always have the root and targets information
-	fmt.Fprintf(cli.Out(), "\nAdministrative keys for %s:\n", remote)
+	fmt.Fprintf(cli.Out(), "\nAdministrative keys for %s:\n", strings.Split(remote, ":")[0])
 	printSortedAdminKeys(adminRoleToKeyIDs, cli)
 
 	return nil

--- a/cli/command/trust/inspect_test.go
+++ b/cli/command/trust/inspect_test.go
@@ -94,6 +94,8 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, cli.OutBuffer().String(), "SIGNERS")
 	// Check for the signer headers
 	assert.Contains(t, cli.OutBuffer().String(), "Administrative keys for alpine:")
+	// make sure the tag isn't included
+	assert.NotContains(t, cli.OutBuffer().String(), "Administrative keys for alpine:3.5")
 	assert.Contains(t, cli.OutBuffer().String(), "3.5")
 	assert.Contains(t, cli.OutBuffer().String(), "(Repo Admin)")
 	// no delegations on this repo
@@ -134,6 +136,8 @@ func TestTrustInfo(t *testing.T) {
 	assert.Contains(t, cli.OutBuffer().String(), "SIGNER")
 	assert.Contains(t, cli.OutBuffer().String(), "KEYS")
 	assert.Contains(t, cli.OutBuffer().String(), "Administrative keys for dockerorcadev/trust-fixture:")
+	// make sure the tag isn't included
+	assert.NotContains(t, cli.OutBuffer().String(), "Administrative keys for dockerorcadev/trust-fixture:unsigned")
 	assert.Contains(t, cli.OutBuffer().String(), "Repository Key")
 	assert.Contains(t, cli.OutBuffer().String(), "Root Key")
 	// all signers have names


### PR DESCRIPTION


![](http://cdn1-www.craveonline.com/assets/uploads/2013/04/man_file_1043906_cats-in-captians-hats-yachting.jpg)


Closes #73

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
