### PR TITLE
Fail fast if the image to sign doesn't exist locally

### DIFF
--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -70,6 +70,10 @@ func signImage(cli command.Cli, imageName string) error {
 	if err != nil {
 		switch err := err.(type) {
 		case client.ErrNoSuchTarget, client.ErrRepositoryNotExist:
+			// Fail fast if the image doesn't exist locally
+			if err := checkLocalImageExistence(ctx, cli, imageName); err != nil {
+				return err
+			}
 			return image.TrustedPush(ctx, cli, repoInfo, ref, *authConfig, requestPrivilege)
 		default:
 			return err


### PR DESCRIPTION
Signed-off-by: Ashwini Oruganti <ashwini.oruganti@gmail.com> (github: ashfall)

Before: 
```
$  ./build/docker-darwin-amd64 trust sign linuxkit/alpine:latest
The push refers to a repository [docker.io/linuxkit/alpine]
An image does not exist locally with the tag: linuxkit/alpine
```
Now:
```
./build/docker-darwin-amd64 trust sign linuxkit/alpine:latest
Error: No such image: linuxkit/alpine:latest
```

![image](https://user-images.githubusercontent.com/1138873/29644517-a4af4b50-882b-11e7-8c79-ecc91c1c7fda.png)

Closes #71 