### PR TITLE
docker trust sign: change message for existing signature and include tag/digest

### DIFF
--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -81,13 +81,13 @@ func signImage(cli command.Cli, imageName string) error {
 	}
 
 	fmt.Fprintf(cli.Out(), "Signing and pushing trust metadata for %s\n", imageName)
-	otherSigners, err := getOtherSigners(notaryRepo, tag)
+	existingSigInfo, err := getExistingSignatureInfoForReleasedTag(notaryRepo, tag)
 	if err != nil {
 		return err
 	}
-	printOtherSigners(otherSigners)
 	err = image.AddTargetToAllSignableRoles(notaryRepo, &target)
 	if err == nil {
+		prettyPrintExistingSignatureInfo(cli, existingSigInfo)
 		err = notaryRepo.Publish()
 	}
 	if err != nil {
@@ -125,25 +125,22 @@ func getReleasedTargetHashAndSize(targets []client.TargetSignedStruct, tag strin
 	return nil, 0, client.ErrNoSuchTarget(tag)
 }
 
-func getOtherSigners(notaryRepo *client.NotaryRepository, tag string) ([]string, error) {
+func getExistingSignatureInfoForReleasedTag(notaryRepo *client.NotaryRepository, tag string) (trustTagRow, error) {
 	targets, err := notaryRepo.GetAllTargetMetadataByName(tag)
-	var signers []string
 	if err != nil {
-		return nil, err
+		return trustTagRow{}, err
 	}
-	for _, tgt := range targets {
-		if !isReleasedTarget(tgt.Role.Name) {
-			signers = append(signers, notaryRoleToSigner(tgt.Role.Name))
-		}
+	releasedTargetInfoList := matchReleasedSignatures(targets)
+	if len(releasedTargetInfoList) == 0 {
+		return trustTagRow{}, nil
 	}
-	return signers, err
+	return releasedTargetInfoList[0], nil
 }
 
-func printOtherSigners(otherSigners []string) {
-	if len(otherSigners) != 0 {
-		fmt.Println("Other signers of this tag:")
-		fmt.Println(strings.Join(otherSigners, ", "))
-	}
+func prettyPrintExistingSignatureInfo(cli command.Cli, existingSigInfo trustTagRow) {
+	sort.Strings(existingSigInfo.Signers)
+	joinedSigners := strings.Join(existingSigInfo.Signers, ", ")
+	fmt.Fprintf(cli.Out(), "Existing signatures for tag %s digest %s from:\n%s\n", existingSigInfo.TagName, existingSigInfo.HashHex, joinedSigners)
 }
 
 func initNotaryRepoWithSigners(notaryRepo *client.NotaryRepository, newSigner data.RoleName) error {


### PR DESCRIPTION
Changed from listing just "Other signers" to also include the tag and digest.  Also, ensures that the other signers come from a released tag over the same digest and tag name by using the `matchReleasedSignatures` function.

Note: I changed the wording to `Existing signatures for...` and do not remove the own user's name if they are a signer

```
🐳 $ ./docker-darwin-amd64 trust sign eiais/trust-demo:1
Signing and pushing trust metadata for eiais/trust-demo:1
Existing signatures for tag 1 digest 74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4 from:
eiais
...
```

![](https://suddenlycat.com/wp-content/uploads/2015/03/Pirate-Cat-Costume1-500x638.jpg)

Closes https://github.com/riyazdf/cli/issues/74