### PR TITLE
trust signer-add

### DIFF
--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -18,6 +18,7 @@ func NewTrustCommand(dockerCli command.Cli) *cobra.Command {
 		newInspectCommand(dockerCli),
 		newRevokeCommand(dockerCli),
 		newSignCommand(dockerCli),
+		newSignerAddCommand(dockerCli),
 	)
 	return cmd
 }

--- a/cli/command/trust/helpers.go
+++ b/cli/command/trust/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/docker/cli/cli/command"
@@ -87,4 +88,52 @@ func clearChangeList(notaryRepo *client.NotaryRepository) error {
 		return err
 	}
 	return nil
+}
+
+// generates an ECDSA key without a GUN for the specified role
+func getOrGenerateNotaryKey(notaryRepo *client.NotaryRepository, role data.RoleName) (data.PublicKey, error) {
+	// use the signer name in the PEM headers if this is a delegation key
+	if data.IsDelegation(role) {
+		role = data.RoleName(notaryRoleToSigner(role))
+	}
+	keys := notaryRepo.CryptoService.ListKeys(role)
+	var err error
+	var key data.PublicKey
+	// always select the first key by ID
+	if len(keys) > 0 {
+		sort.Strings(keys)
+		keyID := keys[0]
+		privKey, _, err := notaryRepo.CryptoService.GetPrivateKey(keyID)
+		if err != nil {
+			return nil, err
+		}
+		key = data.PublicKeyFromPrivate(privKey)
+	} else {
+		key, err = notaryRepo.CryptoService.Create(role, "", data.ECDSAKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return key, nil
+}
+
+// stages changes to add a signer with the specified name and key(s).  Adds to targets/<name> and targets/releases
+func addStagedSigner(notaryRepo *client.NotaryRepository, newSigner data.RoleName, signerKeys []data.PublicKey) {
+	// create targets/<username>
+	notaryRepo.AddDelegationRoleAndKeys(newSigner, signerKeys)
+	notaryRepo.AddDelegationPaths(newSigner, []string{""})
+
+	// create targets/releases
+	notaryRepo.AddDelegationRoleAndKeys(trust.ReleasesRole, signerKeys)
+	notaryRepo.AddDelegationPaths(trust.ReleasesRole, []string{""})
+}
+
+func getOrGenerateRootKeyAndInitRepo(notaryRepo *client.NotaryRepository) error {
+	rootKey, err := getOrGenerateNotaryKey(notaryRepo, data.CanonicalRootRole)
+	if err != nil {
+		return err
+	}
+	// Initialize the notary repository with a remotely managed snapshot
+	// key
+	return notaryRepo.Initialize([]string{rootKey.ID()}, data.CanonicalSnapshotRole)
 }

--- a/cli/command/trust/helpers_test.go
+++ b/cli/command/trust/helpers_test.go
@@ -1,9 +1,19 @@
 package trust
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/docker/cli/cli/trust"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/notary"
+	"github.com/docker/notary/client"
+	"github.com/docker/notary/client/changelist"
+	"github.com/docker/notary/passphrase"
+	"github.com/docker/notary/trustpinning"
+	"github.com/docker/notary/tuf/data"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,4 +32,141 @@ func TestGetTag(t *testing.T) {
 	assert.NoError(t, err)
 	tag, err = getTag(ref)
 	assert.Equal(t, tag, "")
+}
+
+func TestGetOrGenerateNotaryKey(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "notary-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	notaryRepo, err := client.NewFileCachedNotaryRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
+	assert.NoError(t, err)
+
+	// repo is empty, try making a root key
+	rootKeyA, err := getOrGenerateNotaryKey(notaryRepo, data.CanonicalRootRole)
+	assert.NoError(t, err)
+	assert.NotNil(t, rootKeyA)
+
+	// we should only have one newly generated key
+	allKeys := notaryRepo.CryptoService.ListAllKeys()
+	assert.Len(t, allKeys, 1)
+	assert.NotNil(t, notaryRepo.CryptoService.GetKey(rootKeyA.ID()))
+
+	// this time we should get back the same key if we ask for another root key
+	rootKeyB, err := getOrGenerateNotaryKey(notaryRepo, data.CanonicalRootRole)
+	assert.NoError(t, err)
+	assert.NotNil(t, rootKeyB)
+
+	// we should only have one newly generated key
+	allKeys = notaryRepo.CryptoService.ListAllKeys()
+	assert.Len(t, allKeys, 1)
+	assert.NotNil(t, notaryRepo.CryptoService.GetKey(rootKeyB.ID()))
+
+	// The key we retrieved should be identical to the one we generated
+	assert.Equal(t, rootKeyA, rootKeyB)
+
+	// Now also try with a delegation key
+	releasesKey, err := getOrGenerateNotaryKey(notaryRepo, data.RoleName(trust.ReleasesRole))
+	assert.NoError(t, err)
+	assert.NotNil(t, releasesKey)
+
+	// we should now have two keys
+	allKeys = notaryRepo.CryptoService.ListAllKeys()
+	assert.Len(t, allKeys, 2)
+	assert.NotNil(t, notaryRepo.CryptoService.GetKey(releasesKey.ID()))
+	// The key we retrieved should be identical to the one we generated
+	assert.NotEqual(t, releasesKey, rootKeyA)
+	assert.NotEqual(t, releasesKey, rootKeyB)
+}
+
+func TestGetOrGenerateNotaryKeyAndInitRepo(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "notary-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	notaryRepo, err := client.NewFileCachedNotaryRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
+	assert.NoError(t, err)
+
+	err = getOrGenerateRootKeyAndInitRepo(notaryRepo)
+	assert.EqualError(t, err, "client is offline")
+}
+
+func TestAddStageSigners(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "notary-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	notaryRepo, err := client.NewFileCachedNotaryRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
+	assert.NoError(t, err)
+
+	// stage targets/user
+	userRole := data.RoleName("targets/user")
+	userKey := data.NewPublicKey("algoA", []byte("a"))
+	addStagedSigner(notaryRepo, userRole, []data.PublicKey{userKey})
+	// check the changelist for four total changes: two on targets/releases and two on targets/user
+	cl, err := notaryRepo.GetChangelist()
+	assert.NoError(t, err)
+	changeList := cl.List()
+	assert.Len(t, changeList, 4)
+	// ordering is determinstic:
+
+	// first change is for targets/user key creation
+	newSignerKeyChange := changeList[0]
+	expectedJSON, err := json.Marshal(&changelist.TUFDelegation{
+		NewThreshold: notary.MinThreshold,
+		AddKeys:      data.KeyList([]data.PublicKey{userKey}),
+	})
+	expectedChange := changelist.NewTUFChange(
+		changelist.ActionCreate,
+		userRole,
+		changelist.TypeTargetsDelegation,
+		"", // no path for delegations
+		expectedJSON,
+	)
+	assert.Equal(t, expectedChange, newSignerKeyChange)
+
+	// second change is for targets/user getting all paths
+	newSignerPathsChange := changeList[1]
+	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
+		AddPaths: []string{""},
+	})
+	expectedChange = changelist.NewTUFChange(
+		changelist.ActionCreate,
+		userRole,
+		changelist.TypeTargetsDelegation,
+		"", // no path for delegations
+		expectedJSON,
+	)
+	assert.Equal(t, expectedChange, newSignerPathsChange)
+
+	releasesRole := data.RoleName("targets/releases")
+
+	// third change is for targets/releases key creation
+	releasesKeyChange := changeList[2]
+	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
+		NewThreshold: notary.MinThreshold,
+		AddKeys:      data.KeyList([]data.PublicKey{userKey}),
+	})
+	expectedChange = changelist.NewTUFChange(
+		changelist.ActionCreate,
+		releasesRole,
+		changelist.TypeTargetsDelegation,
+		"", // no path for delegations
+		expectedJSON,
+	)
+	assert.Equal(t, expectedChange, releasesKeyChange)
+
+	// fourth change is for targets/releases getting all paths
+	releasesPathsChange := changeList[3]
+	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
+		AddPaths: []string{""},
+	})
+	expectedChange = changelist.NewTUFChange(
+		changelist.ActionCreate,
+		releasesRole,
+		changelist.TypeTargetsDelegation,
+		"", // no path for delegations
+		expectedJSON,
+	)
+	assert.Equal(t, expectedChange, releasesPathsChange)
 }

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -148,14 +148,7 @@ func prettyPrintExistingSignatureInfo(cli command.Cli, existingSigInfo trustTagR
 }
 
 func initNotaryRepoWithSigners(notaryRepo *client.NotaryRepository, newSigner data.RoleName) error {
-	rootKey, err := getOrGenerateNotaryKey(notaryRepo, data.CanonicalRootRole)
-	if err != nil {
-		return err
-	}
-	rootKeyID := rootKey.ID()
-
-	// Initialize the notary repository with a remotely managed snapshot key
-	if err := notaryRepo.Initialize([]string{rootKeyID}, data.CanonicalSnapshotRole); err != nil {
+	if err := getOrGenerateRootKeyAndInitRepo(notaryRepo); err != nil {
 		return err
 	}
 
@@ -166,42 +159,4 @@ func initNotaryRepoWithSigners(notaryRepo *client.NotaryRepository, newSigner da
 	addStagedSigner(notaryRepo, newSigner, []data.PublicKey{signerKey})
 
 	return notaryRepo.Publish()
-}
-
-// generates an ECDSA key without a GUN for the specified role
-func getOrGenerateNotaryKey(notaryRepo *client.NotaryRepository, role data.RoleName) (data.PublicKey, error) {
-	// use the signer name in the PEM headers if this is a delegation key
-	if data.IsDelegation(role) {
-		role = data.RoleName(notaryRoleToSigner(role))
-	}
-	keys := notaryRepo.CryptoService.ListKeys(role)
-	var err error
-	var key data.PublicKey
-	// always select the first key by ID
-	if len(keys) > 0 {
-		sort.Strings(keys)
-		keyID := keys[0]
-		privKey, _, err := notaryRepo.CryptoService.GetPrivateKey(keyID)
-		if err != nil {
-			return nil, err
-		}
-		key = data.PublicKeyFromPrivate(privKey)
-	} else {
-		key, err = notaryRepo.CryptoService.Create(role, "", data.ECDSAKey)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return key, nil
-}
-
-// stages changes to add a signer with the specified name and key(s).  Adds to targets/<name> and targets/releases
-func addStagedSigner(notaryRepo *client.NotaryRepository, newSigner data.RoleName, signerKeys []data.PublicKey) {
-	// create targets/<username>
-	notaryRepo.AddDelegationRoleAndKeys(newSigner, signerKeys)
-	notaryRepo.AddDelegationPaths(newSigner, []string{""})
-
-	// create targets/releases
-	notaryRepo.AddDelegationRoleAndKeys(trust.ReleasesRole, signerKeys)
-	notaryRepo.AddDelegationPaths(trust.ReleasesRole, []string{""})
 }

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -1,18 +1,15 @@
 package trust
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/internal/test"
-	"github.com/docker/cli/cli/trust"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/notary"
 	"github.com/docker/notary/client"
-	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustpinning"
 	"github.com/docker/notary/tuf/data"
@@ -84,131 +81,6 @@ func TestTrustSignErrors(t *testing.T) {
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
-}
-
-func TestGetOrGenerateNotaryKey(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	notaryRepo, err := client.NewFileCachedNotaryRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
-	assert.NoError(t, err)
-
-	// repo is empty, try making a root key
-	rootKeyA, err := getOrGenerateNotaryKey(notaryRepo, data.CanonicalRootRole)
-	assert.NoError(t, err)
-	assert.NotNil(t, rootKeyA)
-
-	// we should only have one newly generated key
-	allKeys := notaryRepo.CryptoService.ListAllKeys()
-	assert.Len(t, allKeys, 1)
-	assert.NotNil(t, notaryRepo.CryptoService.GetKey(rootKeyA.ID()))
-
-	// this time we should get back the same key if we ask for another root key
-	rootKeyB, err := getOrGenerateNotaryKey(notaryRepo, data.CanonicalRootRole)
-	assert.NoError(t, err)
-	assert.NotNil(t, rootKeyB)
-
-	// we should only have one newly generated key
-	allKeys = notaryRepo.CryptoService.ListAllKeys()
-	assert.Len(t, allKeys, 1)
-	assert.NotNil(t, notaryRepo.CryptoService.GetKey(rootKeyB.ID()))
-
-	// The key we retrieved should be identical to the one we generated
-	assert.Equal(t, rootKeyA, rootKeyB)
-
-	// Now also try with a delegation key
-	releasesKey, err := getOrGenerateNotaryKey(notaryRepo, data.RoleName(trust.ReleasesRole))
-	assert.NoError(t, err)
-	assert.NotNil(t, releasesKey)
-
-	// we should now have two keys
-	allKeys = notaryRepo.CryptoService.ListAllKeys()
-	assert.Len(t, allKeys, 2)
-	assert.NotNil(t, notaryRepo.CryptoService.GetKey(releasesKey.ID()))
-	// The key we retrieved should be identical to the one we generated
-	assert.NotEqual(t, releasesKey, rootKeyA)
-	assert.NotEqual(t, releasesKey, rootKeyB)
-}
-
-func TestAddStageSigners(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	notaryRepo, err := client.NewFileCachedNotaryRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
-	assert.NoError(t, err)
-
-	// stage targets/user
-	userRole := data.RoleName("targets/user")
-	userKey := data.NewPublicKey("algoA", []byte("a"))
-	addStagedSigner(notaryRepo, userRole, []data.PublicKey{userKey})
-	// check the changelist for four total changes: two on targets/releases and two on targets/user
-	cl, err := notaryRepo.GetChangelist()
-	assert.NoError(t, err)
-	changeList := cl.List()
-	assert.Len(t, changeList, 4)
-	// ordering is determinstic:
-
-	// first change is for targets/user key creation
-	newSignerKeyChange := changeList[0]
-	expectedJSON, err := json.Marshal(&changelist.TUFDelegation{
-		NewThreshold: notary.MinThreshold,
-		AddKeys:      data.KeyList([]data.PublicKey{userKey}),
-	})
-	expectedChange := changelist.NewTUFChange(
-		changelist.ActionCreate,
-		userRole,
-		changelist.TypeTargetsDelegation,
-		"", // no path for delegations
-		expectedJSON,
-	)
-	assert.Equal(t, expectedChange, newSignerKeyChange)
-
-	// second change is for targets/user getting all paths
-	newSignerPathsChange := changeList[1]
-	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
-		AddPaths: []string{""},
-	})
-	expectedChange = changelist.NewTUFChange(
-		changelist.ActionCreate,
-		userRole,
-		changelist.TypeTargetsDelegation,
-		"", // no path for delegations
-		expectedJSON,
-	)
-	assert.Equal(t, expectedChange, newSignerPathsChange)
-
-	releasesRole := data.RoleName("targets/releases")
-
-	// third change is for targets/releases key creation
-	releasesKeyChange := changeList[2]
-	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
-		NewThreshold: notary.MinThreshold,
-		AddKeys:      data.KeyList([]data.PublicKey{userKey}),
-	})
-	expectedChange = changelist.NewTUFChange(
-		changelist.ActionCreate,
-		releasesRole,
-		changelist.TypeTargetsDelegation,
-		"", // no path for delegations
-		expectedJSON,
-	)
-	assert.Equal(t, expectedChange, releasesKeyChange)
-
-	// fourth change is for targets/releases getting all paths
-	releasesPathsChange := changeList[3]
-	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
-		AddPaths: []string{""},
-	})
-	expectedChange = changelist.NewTUFChange(
-		changelist.ActionCreate,
-		releasesRole,
-		changelist.TypeTargetsDelegation,
-		"", // no path for delegations
-		expectedJSON,
-	)
-	assert.Equal(t, expectedChange, releasesPathsChange)
 }
 
 func TestGetSignedManifestHashAndSize(t *testing.T) {
@@ -288,4 +160,16 @@ func TestChangeList(t *testing.T) {
 	assert.NoError(t, err)
 	cl, err := notaryRepo.GetChangelist()
 	assert.Equal(t, len(cl.List()), 0)
+}
+
+func TestOfflineInitNotaryRepoWithSigners(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "notary-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	notaryRepo, err := client.NewFileCachedNotaryRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
+	assert.NoError(t, err)
+
+	err = initNotaryRepoWithSigners(notaryRepo, data.RoleName(""))
+	assert.EqualError(t, err, "client is offline")
 }

--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -1,0 +1,120 @@
+package trust
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/trust"
+	"github.com/docker/cli/opts"
+	"github.com/docker/notary/client"
+	"github.com/docker/notary/tuf/data"
+	tufutils "github.com/docker/notary/tuf/utils"
+	"github.com/spf13/cobra"
+)
+
+type signerAddOptions struct {
+	keys   opts.ListOpts
+	signer string
+	images []string
+}
+
+func newSignerAddCommand(dockerCli command.Cli) *cobra.Command {
+	var options signerAddOptions
+	cmd := &cobra.Command{
+		Use:   "signer-add [OPTIONS] NAME IMAGE [IMAGE...] ",
+		Short: "Add a signer",
+		Args:  cli.RequiresMinArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			options.signer = args[0]
+			options.images = args[1:]
+			return addSigner(dockerCli, &options)
+		},
+	}
+	flags := cmd.Flags()
+	options.keys = opts.NewListOpts(nil)
+	flags.VarP(&options.keys, "key", "k", "Path to the signer's public key(s)")
+	return cmd
+}
+
+func addSigner(cli command.Cli, options *signerAddOptions) error {
+	signerName := options.signer
+
+	if signerName == "releases" {
+		return fmt.Errorf("releases is a reserved keyword, please use a different signer name")
+	}
+
+	if options.keys.Len() < 1 {
+		return fmt.Errorf("path to a valid public key must be provided")
+	}
+
+	for _, imageName := range options.images {
+		if err := addSignerToImage(cli, signerName, imageName, options.keys.GetAll()); err != nil {
+			fmt.Fprintf(cli.Out(), "Failed to add signer to %s: %s\n", imageName, err)
+			continue
+		}
+		fmt.Fprintf(cli.Out(), "Successfully added signer: %s to %s\n", signerName, imageName)
+	}
+	return nil
+}
+
+func addSignerToImage(cli command.Cli, signerName string, imageName string, keyPaths []string) error {
+	_, ref, repoInfo, authConfig, err := getImageReferencesAndAuth(cli, imageName)
+	if err != nil {
+		return err
+	}
+
+	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, *authConfig, "push", "pull")
+	if err != nil {
+		return trust.NotaryError(ref.Name(), err)
+	}
+
+	if err = notaryRepo.Update(false); err != nil {
+		switch err.(type) {
+		case client.ErrRepoNotInitialized, client.ErrRepositoryNotExist:
+			fmt.Fprintf(cli.Out(), "Initializing signed repository for %s...\n", imageName)
+			if err := getOrGenerateRootKeyAndInitRepo(notaryRepo); err != nil {
+				return trust.NotaryError(ref.Name(), err)
+			}
+			fmt.Fprintf(cli.Out(), "Successfully initialized %q\n", imageName)
+		default:
+			return trust.NotaryError(repoInfo.Name.Name(), err)
+		}
+	}
+
+	fmt.Fprintf(cli.Out(), "\nAdding signer \"%s\" to %s...\n", signerName, imageName)
+	newSignerRoleName := data.RoleName(path.Join(data.CanonicalTargetsRole.String(), signerName))
+
+	signerPubKeys, err := ingestPublicKeys(keyPaths)
+	if err != nil {
+		return err
+	}
+	addStagedSigner(notaryRepo, newSignerRoleName, signerPubKeys)
+
+	return notaryRepo.Publish()
+}
+
+func ingestPublicKeys(pubKeyPaths []string) ([]data.PublicKey, error) {
+	pubKeys := []data.PublicKey{}
+	for _, pubKeyPath := range pubKeyPaths {
+		// Read public key bytes from PEM file
+		pubKeyBytes, err := ioutil.ReadFile(pubKeyPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("file for public key does not exist: %s", pubKeyPath)
+			}
+			return nil, fmt.Errorf("unable to read public key from file: %s", pubKeyPath)
+		}
+
+		// Parse PEM bytes into type PublicKey
+		pubKey, err := tufutils.ParsePEMPublicKey(pubKeyBytes)
+		if err != nil {
+			return nil, err
+		}
+		pubKeys = append(pubKeys, pubKey)
+	}
+	return pubKeys, nil
+}

--- a/cli/command/trust/signer_add_test.go
+++ b/cli/command/trust/signer_add_test.go
@@ -1,0 +1,116 @@
+package trust
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrustSignerAddErrors(t *testing.T) {
+	testCases := []struct {
+		name          string
+		args          []string
+		expectedError string
+	}{
+		{
+			name:          "not-enough-args",
+			expectedError: "requires at least 2 argument",
+		},
+		{
+			name:          "no-key",
+			args:          []string{"foo", "bar"},
+			expectedError: "path to a valid public key must be provided",
+		},
+		{
+			name:          "reserved-releases-signer-add",
+			args:          []string{"releases", "my-image", "-k", "/path/to/key"},
+			expectedError: "releases is a reserved keyword, please use a different signer name",
+		},
+	}
+	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+	config.SetDir(tmpDir)
+
+	for _, tc := range testCases {
+		cmd := newSignerAddCommand(
+			test.NewFakeCli(&fakeClient{}))
+		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+	}
+}
+
+func TestSignerAddCommandNoTargetsKey(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+	config.SetDir(tmpDir)
+
+	tmpfile, err := ioutil.TempFile("", "pemfile")
+	assert.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	cli := test.NewFakeCli(&fakeClient{})
+	cmd := newSignerAddCommand(cli)
+	cmd.SetArgs([]string{"--key", tmpfile.Name(), "alice", "alpine", "linuxkit/alpine"})
+
+	assert.NoError(t, cmd.Execute())
+
+	assert.Contains(t, cli.OutBuffer().String(), "Adding signer \"alice\" to alpine...")
+	assert.Contains(t, cli.OutBuffer().String(), "Failed to add signer to alpine: no valid public key found")
+
+	assert.Contains(t, cli.OutBuffer().String(), "Adding signer \"alice\" to linuxkit/alpine...")
+	assert.Contains(t, cli.OutBuffer().String(), "Failed to add signer to linuxkit/alpine: no valid public key found")
+}
+
+func TestSignerAddCommandBadKeyPath(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+	config.SetDir(tmpDir)
+
+	cli := test.NewFakeCli(&fakeClient{})
+	cmd := newSignerAddCommand(cli)
+	cmd.SetArgs([]string{"--key", "/path/to/key.pem", "alice", "alpine"})
+
+	assert.NoError(t, cmd.Execute())
+
+	expectedError := "\nAdding signer \"alice\" to alpine...\nFailed to add signer to alpine: file for public key does not exist: /path/to/key.pem"
+	assert.Contains(t, cli.OutBuffer().String(), expectedError)
+}
+
+func TestSignerAddCommandInvalidRepoName(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+	config.SetDir(tmpDir)
+
+	cli := test.NewFakeCli(&fakeClient{})
+	cmd := newSignerAddCommand(cli)
+	imageName := "870d292919d01a0af7e7f056271dc78792c05f55f49b9b9012b6d89725bd9abd"
+	cmd.SetArgs([]string{"--key", "/path/to/key.pem", "alice", imageName})
+
+	assert.NoError(t, cmd.Execute())
+
+	expectedError := fmt.Sprintf("Failed to add signer to %s: invalid repository name (%s), cannot specify 64-byte hexadecimal strings\n", imageName, imageName)
+	assert.Equal(t, expectedError, cli.OutBuffer().String())
+}
+
+func TestIngestPublicKeys(t *testing.T) {
+	// Call with a bad path
+	_, err := ingestPublicKeys([]string{"foo", "bar"})
+	assert.EqualError(t, err, "file for public key does not exist: foo")
+	// Call with real file path
+	tmpfile, err := ioutil.TempFile("", "pemfile")
+	assert.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+	_, err = ingestPublicKeys([]string{tmpfile.Name()})
+	assert.EqualError(t, err, "no valid public key found")
+}

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -36,7 +36,8 @@ var (
 	ReleasesRole = data.RoleName(path.Join(data.CanonicalTargetsRole.String(), "releases"))
 )
 
-func trustDirectory() string {
+// GetTrustDirectory returns the base trust directory name
+func GetTrustDirectory() string {
 	return filepath.Join(cliconfig.Dir(), "trust")
 }
 
@@ -165,7 +166,7 @@ func GetNotaryRepository(streams command.Streams, repoInfo *registry.RepositoryI
 	tr := transport.NewTransport(base, modifiers...)
 
 	return client.NewFileCachedNotaryRepository(
-		trustDirectory(),
+		GetTrustDirectory(),
 		data.GUN(repoInfo.Name.Name()),
 		server,
 		tr,


### PR DESCRIPTION
Also moved some helper functions I am reusing from `sign.go` to `helpers.go`.

Example use:
```
./build/docker-darwin-amd64 trust signer-add zed ashfall/test ashfall/test-demo --key ~/demo-keys/cert.pub

Adding signer "zed" to ashfall/test...
Enter passphrase for repository key with ID b5ed45c:
Successfully added signer: zed to ashfall/test

Adding signer "zed" to ashfall/test-demo...
Enter passphrase for repository key with ID 1500c31:
Successfully added signer: zed to ashfall/test-demo
```

![image](https://user-images.githubusercontent.com/1138873/29798041-672f7858-8c0f-11e7-9412-5137bdf94af2.png)
