### PR TITLE
signer-add: Update error message when no key is provided

### DIFF
--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -48,7 +48,7 @@ func addSigner(cli command.Cli, options *signerAddOptions) error {
 	}
 
 	if options.keys.Len() < 1 {
-		return fmt.Errorf("path to a valid public key must be provided")
+		return fmt.Errorf("path to a valid public key must be provided using the `--key` flag")
 	}
 
 	for _, imageName := range options.images {

--- a/cli/command/trust/signer_add_test.go
+++ b/cli/command/trust/signer_add_test.go
@@ -25,7 +25,7 @@ func TestTrustSignerAddErrors(t *testing.T) {
 		{
 			name:          "no-key",
 			args:          []string{"foo", "bar"},
-			expectedError: "path to a valid public key must be provided",
+			expectedError: "path to a valid public key must be provided using the `--key` flag",
 		},
 		{
 			name:          "reserved-releases-signer-add",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1138873/30103983-9758d97a-92f4-11e7-8aff-87ef41421ba8.png)
