### PR TITLE
Add per-key and per-signer status messages, separated by newline

### DIFF
--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -37,6 +37,8 @@ func loadKeys(streams command.Streams, keyPaths []string) error {
 
 	var errKeyPaths []string
 	for _, keyPath := range keyPaths {
+		fmt.Fprintf(streams.Out(), "\nLoading key from \"%s\"...\n", keyPath)
+
 		// Always use a fresh passphrase retriever for each import
 		passRet := trust.GetBlankPassphraseRetriever(streams)
 		if err := loadKeyFromPath(privKeyImporters, keyPath, passRet); err != nil {
@@ -65,6 +67,5 @@ func loadKeyFromPath(privKeyImporters []utils.Importer, keyPath string, passRet 
 		return err
 	}
 	defer from.Close()
-	// Always use a fresh passphrase retriever for each import
 	return utils.ImportKeys(from, privKeyImporters, "signer", "", passRet)
 }

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -69,6 +69,8 @@ func isLastSignerForReleases(roleWithSig data.Role, allRoles []client.RoleWithSi
 }
 
 func removeSingleSigner(cli command.Cli, image, signerName string, forceYes bool) error {
+	fmt.Fprintf(cli.Out(), "\nRemoving signer \"%s\" from %s...\n", signerName, image)
+
 	_, ref, repoInfo, authConfig, err := getImageReferencesAndAuth(cli, image)
 	if err != nil {
 		return err

--- a/cli/command/trust/signer_remove_test.go
+++ b/cli/command/trust/signer_remove_test.go
@@ -69,8 +69,18 @@ func TestRemoveSingleSigner(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
 	err := removeSingleSigner(cli, "eiais/test2", "test", true)
 	assert.EqualError(t, err, "No signer test for image eiais/test2")
+	assert.Contains(t, cli.OutBuffer().String(), "\nRemoving signer \"test\" from eiais/test2...\n")
 	err = removeSingleSigner(cli, "eiais/test2", "releases", true)
 	assert.EqualError(t, err, "releases is a reserved keyword and cannot be removed")
+	assert.Contains(t, cli.OutBuffer().String(), "\nRemoving signer \"releases\" from eiais/test2...\n")
+}
+
+func TestRemoveMultipleSigners(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{})
+	err := removeSigner(cli, "test", []string{"repo1", "repo2"}, &signerRemoveOptions{forceYes: true})
+	assert.EqualError(t, err, "Error removing signer from: repo1, repo2")
+	assert.Contains(t, cli.OutBuffer().String(),
+		"\nRemoving signer \"test\" from repo1...\nError retrieving signers for repo1\n\nRemoving signer \"test\" from repo2...\nError retrieving signers for repo2")
 }
 
 func TestIsLastSignerForReleases(t *testing.T) {


### PR DESCRIPTION
Adds a status message to `docker trust key-load` and `docker trust signer-remove` when operating on a key-path/signer, separated by newline for easier reading.  Also fixes an extraneous comment.

![many-cats-many-hats](https://i.pinimg.com/236x/8a/15/a6/8a15a6ff662e8188e6f7362e0d47b96f.jpg)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>