### PR TITLE
docker trust key-generate, fixes for key-load

### DIFF
--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -15,6 +15,7 @@ func NewTrustCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 	}
 	cmd.AddCommand(
+		newKeyGenerateCommand(dockerCli),
 		newKeyLoadCommand(dockerCli),
 		newInspectCommand(dockerCli),
 		newRevokeCommand(dockerCli),

--- a/cli/command/trust/key_generate.go
+++ b/cli/command/trust/key_generate.go
@@ -1,0 +1,108 @@
+package trust
+
+import (
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/trust"
+	"github.com/docker/notary"
+	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/tuf/data"
+	tufutils "github.com/docker/notary/tuf/utils"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func newKeyGenerateCommand(dockerCli command.Streams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "key-generate NAME [NAME...]",
+		Short: "Generate a signing key",
+		Args:  cli.RequiresMinArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return generateKeys(dockerCli, args)
+		},
+	}
+	return cmd
+}
+
+func generateKeys(streams command.Streams, keyNames []string) error {
+	var genKeyErrs []string
+	for _, keyName := range keyNames {
+		if err := generateKey(streams, keyName); err != nil {
+			fmt.Fprintf(streams.Out(), err.Error())
+			genKeyErrs = append(genKeyErrs, keyName)
+		}
+	}
+
+	if len(genKeyErrs) > 0 {
+		return fmt.Errorf("Error generating keys for: %s", strings.Join(genKeyErrs, ", "))
+	}
+	return nil
+}
+
+func generateKey(streams command.Streams, keyName string) error {
+	fmt.Fprintf(streams.Out(), "\nGenerating key for %s...\n", keyName)
+	privKey, err := tufutils.GenerateKey(data.ECDSAKey)
+	if err != nil {
+		return err
+	}
+	var (
+		chosenPassphrase string
+		giveup           bool
+		pemPrivKey       []byte
+	)
+	keyID := privKey.ID()
+	passRet := trust.GetPassphraseRetriever(streams.In(), streams.Out())
+	fmt.Fprintf(streams.Out(), "Encrypting private key material for %s...\n", keyName)
+	for attempts := 0; ; attempts++ {
+		chosenPassphrase, giveup, err = passRet(keyID, "", true, attempts)
+		if err == nil {
+			break
+		}
+		if giveup || attempts > 10 {
+			return trustmanager.ErrAttemptsExceeded{}
+		}
+	}
+
+	if chosenPassphrase != "" {
+		pemPrivKey, err = tufutils.ConvertPrivateKeyToPKCS8(privKey, data.RoleName(keyName), "", chosenPassphrase)
+		if err != nil {
+			return err
+		}
+	} else {
+		return errors.New("no password provided")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	privFileName := strings.Join([]string{strings.Join([]string{keyName, "key"}, "-"), "priv"}, ".")
+	privFilePath := filepath.Join(cwd, privFileName)
+	pubFileName := strings.Join([]string{keyName, "pub"}, ".")
+	pubFilePath := filepath.Join(cwd, pubFileName)
+
+	err = ioutil.WriteFile(privFilePath, pemPrivKey, notary.PrivNoExecPerms)
+	if err != nil {
+		return err
+	}
+
+	pubKey := data.PublicKeyFromPrivate(privKey)
+	pubPEM := pem.Block{
+		Type: "PUBLIC KEY",
+		Headers: map[string]string{
+			"role": keyName,
+		},
+		Bytes: pubKey.Public(),
+	}
+	if err := ioutil.WriteFile(pubFilePath, pem.EncodeToMemory(&pubPEM), notary.PrivNoExecPerms); err != nil {
+		return err
+	}
+	fmt.Fprintf(streams.Out(), "Successfully generated encrypted private key %s and public key %s\n", privFileName, pubFileName)
+	return nil
+}

--- a/cli/command/trust/key_generate.go
+++ b/cli/command/trust/key_generate.go
@@ -83,8 +83,5 @@ func generateKey(keyName, pubDir, privTrustDir string, passRet notary.PassRetrie
 	// Output the public key to a file in the CWD
 	pubFileName := strings.Join([]string{keyName, "pub"}, ".")
 	pubFilePath := filepath.Join(pubDir, pubFileName)
-	if err := ioutil.WriteFile(pubFilePath, pem.EncodeToMemory(&pubPEM), notary.PrivNoExecPerms); err != nil {
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(pubFilePath, pem.EncodeToMemory(&pubPEM), notary.PrivNoExecPerms)
 }

--- a/cli/command/trust/key_generate_test.go
+++ b/cli/command/trust/key_generate_test.go
@@ -1,13 +1,18 @@
 package trust
 
 import (
+	"encoding/pem"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/testutil"
+	"github.com/docker/notary"
+	"github.com/docker/notary/passphrase"
+	tufutils "github.com/docker/notary/tuf/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,4 +39,64 @@ func TestTrustKeyGenerateErrors(t *testing.T) {
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
+}
+
+func TestGenerateKeySuccess(t *testing.T) {
+	pubKeyCWD, err := ioutil.TempDir("", "pub-keys-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(pubKeyCWD)
+
+	privKeyStorageDir, err := ioutil.TempDir("", "priv-keys-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(privKeyStorageDir)
+
+	passwd := "password"
+	cannedPasswordRetriever := passphrase.ConstantRetriever(passwd)
+	// generate a single key
+	keyName := "alice"
+	assert.NoError(t, generateKey(keyName, pubKeyCWD, privKeyStorageDir, cannedPasswordRetriever))
+
+	// check that the public key exists:
+	expectedPubKeyPath := filepath.Join(pubKeyCWD, keyName+".pub")
+	_, err = os.Stat(expectedPubKeyPath)
+	assert.NoError(t, err)
+	// check that the public key is the only file output in CWD
+	cwdKeyFiles, err := ioutil.ReadDir(pubKeyCWD)
+	assert.NoError(t, err)
+	assert.Len(t, cwdKeyFiles, 1)
+
+	// verify the key header is set with the specified name
+	from, _ := os.OpenFile(expectedPubKeyPath, os.O_RDONLY, notary.PrivExecPerms)
+	defer from.Close()
+	fromBytes, _ := ioutil.ReadAll(from)
+	keyPEM, _ := pem.Decode(fromBytes)
+	assert.Equal(t, keyName, keyPEM.Headers["role"])
+	// the default GUN is empty
+	assert.Equal(t, "", keyPEM.Headers["gun"])
+	// assert public key header
+	assert.Equal(t, "PUBLIC KEY", keyPEM.Type)
+
+	// check that an appropriate ~/<trust_dir>/private/<key_id>.key file exists
+	expectedPrivKeyDir := filepath.Join(privKeyStorageDir, notary.PrivDir)
+	_, err = os.Stat(expectedPrivKeyDir)
+	assert.NoError(t, err)
+
+	keyFiles, err := ioutil.ReadDir(expectedPrivKeyDir)
+	assert.NoError(t, err)
+	assert.Len(t, keyFiles, 1)
+	privKeyFilePath := filepath.Join(expectedPrivKeyDir, keyFiles[0].Name())
+
+	// verify the key content
+	privFrom, _ := os.OpenFile(privKeyFilePath, os.O_RDONLY, notary.PrivExecPerms)
+	defer privFrom.Close()
+	fromBytes, _ = ioutil.ReadAll(privFrom)
+	keyPEM, _ = pem.Decode(fromBytes)
+	assert.Equal(t, keyName, keyPEM.Headers["role"])
+	// the default GUN is empty
+	assert.Equal(t, "", keyPEM.Headers["gun"])
+	// assert encrypted header
+	assert.Equal(t, "ENCRYPTED PRIVATE KEY", keyPEM.Type)
+	// check that the passphrase matches
+	_, err = tufutils.ParsePKCS8ToTufKey(keyPEM.Bytes, []byte(passwd))
+	assert.NoError(t, err)
 }

--- a/cli/command/trust/key_generate_test.go
+++ b/cli/command/trust/key_generate_test.go
@@ -1,0 +1,37 @@
+package trust
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/internal/test"
+	"github.com/docker/cli/internal/test/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrustKeyGenerateErrors(t *testing.T) {
+	testCases := []struct {
+		name          string
+		args          []string
+		expectedError string
+	}{
+		{
+			name:          "not-enough-args",
+			expectedError: "requires at least 1 argument",
+		},
+	}
+	tmpDir, err := ioutil.TempDir("", "docker-key-load-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+	config.SetDir(tmpDir)
+
+	for _, tc := range testCases {
+		cli := test.NewFakeCli(&fakeClient{})
+		cmd := newKeyGenerateCommand(cli)
+		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+	}
+}

--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -79,7 +79,7 @@ func loadPrivKeyFromPath(privKeyImporters []utils.Importer, keyPath, keyName str
 		return err
 	}
 	if _, _, err := tufutils.ExtractPrivateKeyAttributes(keyBytes); err != nil {
-		return fmt.Errorf("provided file %s is not a supported private key", keyPath)
+		return fmt.Errorf("provided file %s is not a supported private key - to add a signer's public key use docker trust signer-add", keyPath)
 	}
 	// Rewind the file pointer
 	if _, err := from.Seek(0, 0); err != nil {

--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -2,15 +2,16 @@ package trust
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/notary"
 	"github.com/docker/notary/storage"
+	tufutils "github.com/docker/notary/tuf/utils"
 	"github.com/docker/notary/utils"
 	"github.com/spf13/cobra"
 )
@@ -20,19 +21,26 @@ const (
 	ownerReadAndWritePerms = 0600
 )
 
+type keyLoadOptions struct {
+	keyName string
+}
+
 func newKeyLoadCommand(dockerCli command.Streams) *cobra.Command {
+	var options keyLoadOptions
 	cmd := &cobra.Command{
-		Use:   "key-load KEY [KEY...] ",
-		Short: "Load a signing key",
-		Args:  cli.RequiresMinArgs(1),
+		Use:   "key-load KEY",
+		Short: "Load a private key file for signing",
+		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return loadKeys(dockerCli, args)
+			return loadPrivKey(dockerCli, args[0], options)
 		},
 	}
+	flags := cmd.Flags()
+	flags.StringVarP(&options.keyName, "name", "n", "signer", "Name for the loaded key")
 	return cmd
 }
 
-func loadKeys(streams command.Streams, keyPaths []string) error {
+func loadPrivKey(streams command.Streams, keyPath string, options keyLoadOptions) error {
 	trustDir := trust.GetTrustDirectory()
 	keyFileStore, err := storage.NewPrivateKeyFileStorage(filepath.Join(trustDir, notary.PrivDir), notary.KeyExtension)
 	if err != nil {
@@ -40,26 +48,18 @@ func loadKeys(streams command.Streams, keyPaths []string) error {
 	}
 	privKeyImporters := []utils.Importer{keyFileStore}
 
-	var errKeyPaths []string
-	for _, keyPath := range keyPaths {
-		fmt.Fprintf(streams.Out(), "\nLoading key from \"%s\"...\n", keyPath)
+	fmt.Fprintf(streams.Out(), "\nLoading key from \"%s\"...\n", keyPath)
 
-		// Always use a fresh passphrase retriever for each import
-		passRet := trust.GetPassphraseRetriever(streams.In(), streams.Out())
-		if err := loadKeyFromPath(privKeyImporters, keyPath, passRet); err != nil {
-			fmt.Fprintf(streams.Out(), "error importing key from %s: %s\n", keyPath, err)
-			errKeyPaths = append(errKeyPaths, keyPath)
-		} else {
-			fmt.Fprintf(streams.Out(), "Successfully imported key from %s\n", keyPath)
-		}
+	// Always use a fresh passphrase retriever for each import
+	passRet := trust.GetPassphraseRetriever(streams.In(), streams.Out())
+	if err := loadPrivKeyFromPath(privKeyImporters, keyPath, options.keyName, passRet); err != nil {
+		return fmt.Errorf("error importing key from %s: %s", keyPath, err)
 	}
-	if len(errKeyPaths) > 0 {
-		return fmt.Errorf("Error importing keys from: %s", strings.Join(errKeyPaths, ", "))
-	}
+	fmt.Fprintf(streams.Out(), "Successfully imported key from %s\n", keyPath)
 	return nil
 }
 
-func loadKeyFromPath(privKeyImporters []utils.Importer, keyPath string, passRet notary.PassRetriever) error {
+func loadPrivKeyFromPath(privKeyImporters []utils.Importer, keyPath, keyName string, passRet notary.PassRetriever) error {
 	fileInfo, err := os.Stat(keyPath)
 	if err != nil {
 		return err
@@ -67,10 +67,24 @@ func loadKeyFromPath(privKeyImporters []utils.Importer, keyPath string, passRet 
 	if fileInfo.Mode() != ownerReadOnlyPerms && fileInfo.Mode() != ownerReadAndWritePerms {
 		return fmt.Errorf("private key permission from %s should be set to 400 or 600", keyPath)
 	}
+
 	from, err := os.OpenFile(keyPath, os.O_RDONLY, notary.PrivExecPerms)
 	if err != nil {
 		return err
 	}
 	defer from.Close()
-	return utils.ImportKeys(from, privKeyImporters, "signer", "", passRet)
+
+	keyBytes, err := ioutil.ReadAll(from)
+	if err != nil {
+		return err
+	}
+	if _, _, err := tufutils.ExtractPrivateKeyAttributes(keyBytes); err != nil {
+		return fmt.Errorf("provided file %s is not a supported private key", keyPath)
+	}
+	// Rewind the file pointer
+	if _, err := from.Seek(0, 0); err != nil {
+		return err
+	}
+
+	return utils.ImportKeys(from, privKeyImporters, keyName, "", passRet)
 }

--- a/cli/command/trust/key_load_test.go
+++ b/cli/command/trust/key_load_test.go
@@ -156,27 +156,27 @@ func TestLoadKeyTooPermissive(t *testing.T) {
 	privKeyFilepath = filepath.Join(privKeyDir, "privkey667.pem")
 	assert.NoError(t, ioutil.WriteFile(privKeyFilepath, privKeyFixture, 0677))
 
-	err = loadKeyFromPath(privKeyImporters, privKeyFilepath, cannedPasswordRetriever)
+	err = loadPrivKeyFromPath(privKeyImporters, privKeyFilepath, "signer", cannedPasswordRetriever)
 	assert.Error(t, err)
 	assert.Contains(t, fmt.Sprintf("private key permission from %s should be set to 400 or 600", privKeyFilepath), err.Error())
 
 	privKeyFilepath = filepath.Join(privKeyDir, "privkey777.pem")
 	assert.NoError(t, ioutil.WriteFile(privKeyFilepath, privKeyFixture, 0777))
 
-	err = loadKeyFromPath(privKeyImporters, privKeyFilepath, cannedPasswordRetriever)
+	err = loadPrivKeyFromPath(privKeyImporters, privKeyFilepath, "signer", cannedPasswordRetriever)
 	assert.Error(t, err)
 	assert.Contains(t, fmt.Sprintf("private key permission from %s should be set to 400 or 600", privKeyFilepath), err.Error())
 
 	privKeyFilepath = filepath.Join(privKeyDir, "privkey400.pem")
 	assert.NoError(t, ioutil.WriteFile(privKeyFilepath, privKeyFixture, 0400))
 
-	err = loadKeyFromPath(privKeyImporters, privKeyFilepath, cannedPasswordRetriever)
+	err = loadPrivKeyFromPath(privKeyImporters, privKeyFilepath, "signer", cannedPasswordRetriever)
 	assert.NoError(t, err)
 
 	privKeyFilepath = filepath.Join(privKeyDir, "privkey600.pem")
 	assert.NoError(t, ioutil.WriteFile(privKeyFilepath, privKeyFixture, 0600))
 
-	err = loadKeyFromPath(privKeyImporters, privKeyFilepath, cannedPasswordRetriever)
+	err = loadPrivKeyFromPath(privKeyImporters, privKeyFilepath, "signer", cannedPasswordRetriever)
 	assert.NoError(t, err)
 }
 
@@ -204,5 +204,5 @@ func TestLoadPubKeyFailure(t *testing.T) {
 	// import the key to our keyStorageDir - it should fail
 	err = loadPrivKeyFromPath(privKeyImporters, pubKeyFilepath, "signer", cannedPasswordRetriever)
 	assert.Error(t, err)
-	assert.Contains(t, fmt.Sprintf("provided file %s is not a supported private key", pubKeyFilepath), err.Error())
+	assert.Contains(t, fmt.Sprintf("provided file %s is not a supported private key - to add a signer's public key use docker trust signer-add", pubKeyFilepath), err.Error())
 }

--- a/cli/command/trust/key_load_test.go
+++ b/cli/command/trust/key_load_test.go
@@ -28,20 +28,20 @@ func TestTrustKeyLoadErrors(t *testing.T) {
 	}{
 		{
 			name:           "not-enough-args",
-			expectedError:  "requires at least 1 argument",
+			expectedError:  "exactly 1 argument",
+			expectedOutput: "",
+		},
+		{
+			name:           "too-many-args",
+			args:           []string{"iamnotakey", "alsonotakey"},
+			expectedError:  "exactly 1 argument",
 			expectedOutput: "",
 		},
 		{
 			name:           "not-a-key",
 			args:           []string{"iamnotakey"},
-			expectedError:  "Error importing keys from: iamnotakey",
-			expectedOutput: "\nLoading key from \"iamnotakey\"...\nerror importing key from iamnotakey: stat iamnotakey: no such file or directory",
-		},
-		{
-			name:           "multiple-not-a-key",
-			args:           []string{"iamnotakey", "alsonotakey"},
-			expectedError:  "Error importing keys from: iamnotakey, alsonotakey",
-			expectedOutput: "\nLoading key from \"iamnotakey\"...\nerror importing key from iamnotakey: stat iamnotakey: no such file or directory\n\nLoading key from \"alsonotakey\"...\n",
+			expectedError:  "error importing key from iamnotakey: stat iamnotakey: no such file or directory",
+			expectedOutput: "\nLoading key from \"iamnotakey\"...\n",
 		},
 	}
 	tmpDir, err := ioutil.TempDir("", "docker-key-load-test-")
@@ -107,7 +107,7 @@ func TestLoadKeyFromPath(t *testing.T) {
 	privKeyImporters := []utils.Importer{keyFileStore}
 
 	// import the key to our keyStorageDir
-	assert.NoError(t, loadKeyFromPath(privKeyImporters, privKeyFilepath, cannedPasswordRetriever))
+	assert.NoError(t, loadPrivKeyFromPath(privKeyImporters, privKeyFilepath, "signer-name", cannedPasswordRetriever))
 
 	// check that the appropriate ~/<trust_dir>/private/<key_id>.key file exists
 	expectedImportKeyPath := filepath.Join(keyStorageDir, notary.PrivDir, privKeyID+"."+notary.KeyExtension)
@@ -119,8 +119,7 @@ func TestLoadKeyFromPath(t *testing.T) {
 	defer from.Close()
 	fromBytes, _ := ioutil.ReadAll(from)
 	keyPEM, _ := pem.Decode(fromBytes)
-	// the default role is: signer
-	assert.Equal(t, "signer", keyPEM.Headers["role"])
+	assert.Equal(t, "signer-name", keyPEM.Headers["role"])
 	// the default GUN is empty
 	assert.Equal(t, "", keyPEM.Headers["gun"])
 	// assert encrypted header
@@ -150,7 +149,7 @@ func TestLoadKeyTooPermissive(t *testing.T) {
 	privKeyImporters := []utils.Importer{keyFileStore}
 
 	// import the key to our keyStorageDir
-	err = loadKeyFromPath(privKeyImporters, privKeyFilepath, cannedPasswordRetriever)
+	err = loadPrivKeyFromPath(privKeyImporters, privKeyFilepath, "signer", cannedPasswordRetriever)
 	assert.Error(t, err)
 	assert.Contains(t, fmt.Sprintf("private key permission from %s should be set to 400 or 600", privKeyFilepath), err.Error())
 
@@ -179,4 +178,31 @@ func TestLoadKeyTooPermissive(t *testing.T) {
 
 	err = loadKeyFromPath(privKeyImporters, privKeyFilepath, cannedPasswordRetriever)
 	assert.NoError(t, err)
+}
+
+var pubKeyFixture = []byte(`-----BEGIN PUBLIC KEY-----
+	MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUIH9AYtrcDFzZrFJBdJZkn21d+4c
+	H3nzy2O6Q/ct4BjOBKa+WCdRtPo78bA+C/7t81ADQO8Jqaj59W50rwoqDQ==
+	-----END PUBLIC KEY-----`)
+
+func TestLoadPubKeyFailure(t *testing.T) {
+	pubKeyDir, err := ioutil.TempDir("", "key-load-test-pubkey-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(pubKeyDir)
+	pubKeyFilepath := filepath.Join(pubKeyDir, "pubkey.pem")
+	assert.NoError(t, ioutil.WriteFile(pubKeyFilepath, pubKeyFixture, notary.PrivNoExecPerms))
+	keyStorageDir, err := ioutil.TempDir("", "loaded-keys-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(keyStorageDir)
+
+	passwd := "password"
+	cannedPasswordRetriever := passphrase.ConstantRetriever(passwd)
+	keyFileStore, err := storage.NewPrivateKeyFileStorage(keyStorageDir, notary.KeyExtension)
+	assert.NoError(t, err)
+	privKeyImporters := []utils.Importer{keyFileStore}
+
+	// import the key to our keyStorageDir - it should fail
+	err = loadPrivKeyFromPath(privKeyImporters, pubKeyFilepath, "signer", cannedPasswordRetriever)
+	assert.Error(t, err)
+	assert.Contains(t, fmt.Sprintf("provided file %s is not a supported private key", pubKeyFilepath), err.Error())
 }


### PR DESCRIPTION
Allow for users to generate one or more named keys.  Writes a  public key `keyName.pub`to the CWD and loads the private key into the appropriate trust directory. 

Also includes updates to `key-load` to make it only operate on a single key and allow giving a `--name` argument to explicitly name the key

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
