### PR TITLE
cmd: fixup double commands from rebasing

### DIFF
--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -21,9 +21,6 @@ func NewTrustCommand(dockerCli command.Cli) *cobra.Command {
 		newSignCommand(dockerCli),
 		newSignerAddCommand(dockerCli),
 		newSignerRemoveCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newRevokeCommand(dockerCli),
-		newSignCommand(dockerCli),
 	)
 	return cmd
 }


### PR DESCRIPTION
rebase snafu led to double inspect/revoke/sign commands being defined

<img src="http://slappedham.com/wp-content/uploads/2015/08/Cat-dressed-as-a-lion.jpg" width="400"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
