### PR TITLE
[OPTIONS] in all cli commands

### DIFF
--- a/cli/command/trust/key_generate.go
+++ b/cli/command/trust/key_generate.go
@@ -21,7 +21,7 @@ import (
 
 func newKeyGenerateCommand(dockerCli command.Streams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "key-generate NAME [NAME...]",
+		Use:   "key-generate [OPTIONS] NAME [NAME...]",
 		Short: "Generate and load a signing key-pair",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -28,7 +28,7 @@ type keyLoadOptions struct {
 func newKeyLoadCommand(dockerCli command.Streams) *cobra.Command {
 	var options keyLoadOptions
 	cmd := &cobra.Command{
-		Use:   "key-load KEY",
+		Use:   "key-load [OPTIONS] KEY",
 		Short: "Load a private key file for signing",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -23,7 +23,7 @@ type signerRemoveOptions struct {
 func newSignerRemoveCommand(dockerCli command.Cli) *cobra.Command {
 	options := signerRemoveOptions{}
 	cmd := &cobra.Command{
-		Use:   "signer-remove NAME IMAGE [IMAGE...]",
+		Use:   "signer-remove [OPTIONS] NAME IMAGE [IMAGE...]",
 		Short: "Remove a signer",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
We were missing `[OPTIONS]` for `signer-remove` and `key-load` -- marking as WIP because we should merge #106 first and then apply this to `key-generate` as well.

<img src="https://i.pinimg.com/736x/d8/2b/b4/d82bb4bfc6b8f211cde5fcbbc14588d1--shark-hat-cat-shark.jpg" width="400"></img>