### PR TITLE
signer-remove: add test for new output on warning

### DIFF
--- a/cli/command/trust/client_test.go
+++ b/cli/command/trust/client_test.go
@@ -316,7 +316,39 @@ func (l LoadedNotaryRepository) ListRoles() ([]client.RoleWithSignatures, error)
 		Name: data.CanonicalTargetsRole,
 	}
 
-	return []client.RoleWithSignatures{{Role: rootRole}, {Role: targetsRole}}, nil
+	aliceRole := data.Role{
+		RootRole: data.RootRole{
+			KeyIDs:    []string{"A"},
+			Threshold: 1,
+		},
+		Name: data.RoleName("targets/alice"),
+	}
+
+	bobRole := data.Role{
+		RootRole: data.RootRole{
+			KeyIDs:    []string{"B"},
+			Threshold: 1,
+		},
+		Name: data.RoleName("targets/bob"),
+	}
+
+	releasesRole := data.Role{
+		RootRole: data.RootRole{
+			KeyIDs:    []string{"A", "B"},
+			Threshold: 1,
+		},
+		Name: data.RoleName("targets/releases"),
+	}
+	// have releases only signed off by Alice last
+	releasesSig := []data.Signature{{KeyID: "A"}}
+
+	return []client.RoleWithSignatures{
+		{Role: rootRole},
+		{Role: targetsRole},
+		{Role: aliceRole},
+		{Role: bobRole},
+		{Role: releasesRole, Signatures: releasesSig},
+	}, nil
 }
 
 func (l LoadedNotaryRepository) ListTargets(roles ...data.RoleName) ([]*client.TargetWithRole, error) {

--- a/cli/command/trust/signer_remove_test.go
+++ b/cli/command/trust/signer_remove_test.go
@@ -86,6 +86,16 @@ func TestRemoveMultipleSigners(t *testing.T) {
 	assert.Contains(t, cli.OutBuffer().String(),
 		"\nRemoving signer \"test\" from signed-repo...\nNo signer test for image signed-repo\n\nRemoving signer \"test\" from signed-repo...\nNo signer test for image signed-repo")
 }
+func TestRemoveLastSignerWarning(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{})
+	cli.SetNotaryClient(getLoadedNotaryRepository)
+	err := removeSigner(cli, "alice", []string{"signed-repo"}, &signerRemoveOptions{forceYes: false})
+	assert.NoError(t, err)
+	assert.Contains(t, cli.OutBuffer().String(),
+		"The signer \"alice\" signed the last released version of signed-repo. "+
+			"Removing this signer will make signed-repo unpullable. "+
+			"Are you sure you want to continue? [y/N]")
+}
 
 func TestIsLastSignerForReleases(t *testing.T) {
 	role := data.Role{}


### PR DESCRIPTION
@ashfall: I found a way to mock such that we can test the new wording - test is included in this PR.

